### PR TITLE
General assets view

### DIFF
--- a/app/helpers/assets_helper.rb
+++ b/app/helpers/assets_helper.rb
@@ -1,0 +1,10 @@
+module AssetsHelper
+  def asset_value(coin, amount)
+    number_to_currency coin.rate * amount
+  end
+
+  def asset_percentage(coin, amount, net_worth)
+    number_to_percentage coin.rate * amount / net_worth * 100,
+                         precision: 2
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,7 +1,7 @@
 class Account < ApplicationRecord
   belongs_to :owner, class_name: 'User'
   has_many :portfolios, dependent: :destroy
-  has_many :holdings, through: :portfolio
+  has_many :holdings, through: :portfolios
 
   validates :uuid, presence: true
   validates :owner, :uuid, uniqueness: true
@@ -10,6 +10,10 @@ class Account < ApplicationRecord
 
   def net_worth
     portfolios.map(&:total_balance).sum
+  end
+
+  def assets
+    holdings.group(:coin).sum(:amount)
   end
 
   private

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -22,15 +22,17 @@
           <th>Rate</th>
           <th>Balance</th>
           <th>USD</th>
+          <th>%</th>
         </tr>
       </thead>
       <tbody>
         <% @account.assets.each_pair do |coin, amount| %>
           <tr>
             <td><%= coin.ticker %></td>
-            <td><%= number_to_currency coin.rate.round(2) %></td>
+            <td><%= number_to_currency coin.rate.round 2 %></td>
             <td><%= amount %></td>
-            <td><%= number_to_currency(coin.rate * amount) %></td>
+            <td><%= asset_value coin, amount %></td>
+            <td><%= asset_percentage coin, amount, @account.net_worth %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -13,7 +13,7 @@
   <hr>
   
   <div>
-    <h3>Assets</h3>
+    <h3>Account assets</h3>
     
     <table>
       <thead>
@@ -24,7 +24,16 @@
           <th>USD</th>
         </tr>
       </thead>
-      <tbody></tbody>
+      <tbody>
+        <% @account.assets.each_pair do |coin, amount| %>
+          <tr>
+            <td><%= coin.ticker %></td>
+            <td><%= number_to_currency coin.rate.round(2) %></td>
+            <td><%= amount %></td>
+            <td><%= number_to_currency(coin.rate * amount) %></td>
+          </tr>
+        <% end %>
+      </tbody>
     </table>
   </div>
 </section>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -30,7 +30,7 @@
           <tr>
             <td><%= coin.ticker %></td>
             <td><%= number_to_currency coin.rate.round 2 %></td>
-            <td><%= amount %></td>
+            <td><%= amount.round 4 %></td>
             <td><%= asset_value coin, amount %></td>
             <td><%= asset_percentage coin, amount, @account.net_worth %></td>
           </tr>

--- a/app/views/holdings/_holding.html.erb
+++ b/app/views/holdings/_holding.html.erb
@@ -6,7 +6,7 @@
     <%= number_to_currency holding.rate.round(2) %>
   </td>
   <td class="border p-1">
-    <%= holding.amount %>
+    <%= holding.amount.round 4 %>
   </td>
   <td class="border p-1">
     <%= number_to_currency holding.value.round(2) %>

--- a/spec/helpers/assets_helper_spec.rb
+++ b/spec/helpers/assets_helper_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe AssetsHelper, type: :helper do
+  describe '.asset_value' do
+    it 'returns formatted value in USD' do
+      coin   = create :coin, rate: 909.9
+      amount = 2.5
+
+      expect(asset_value(coin, amount)).to eq '$2,274.75'
+    end
+  end
+
+  describe '.asset_percentage' do
+    it 'returns the proprtion of an asset in an account' do
+      coin_a = create :coin, rate: 5.0
+      coin_b = create :coin, rate: 10.0
+      coin_c = create :coin, rate: 15.0
+      account = create(:user).account
+      portfolio = create(:portfolio, account:)
+      holding_a = create :holding, portfolio:, coin: coin_a, amount: 1.0
+      holding_b = create :holding, portfolio:, coin: coin_b, amount: 2.0
+      holding_c = create :holding, portfolio:, coin: coin_c, amount: 3.0
+
+      percentage_a = asset_percentage(coin_a, holding_a.amount, account.net_worth)
+      percentage_b = asset_percentage(coin_b, holding_b.amount, account.net_worth)
+      percentage_c = asset_percentage(coin_c, holding_c.amount, account.net_worth)
+
+      expect(percentage_a).to eq '7.14%'
+      expect(percentage_b).to eq '28.57%'
+      expect(percentage_c).to eq '64.29%'
+    end
+  end
+end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -63,4 +63,32 @@ RSpec.describe Account, type: :model do
       expect(account.net_worth).to eq 0
     end
   end
+
+  describe '#assets' do
+    it 'Returns aggregated list of all the account\'s assets and their amounts' do
+      coin_a = create :coin, ticker: 'CNA', rate: 1.11
+      coin_b = create :coin, ticker: 'CNB', rate: 2.22
+      coin_c = create :coin, ticker: 'CNC', rate: 3.33
+      coin_d = create :coin, ticker: 'CND', rate: 4.44
+      user = create :user
+      portfolio1 = create :portfolio, account: user.account
+      portfolio2 = create :portfolio, account: user.account
+      portfolio1.holdings.create([{ coin: coin_a, amount: 5.5 },
+                                  { coin: coin_b, amount: 6.6 },
+                                  { coin: coin_c, amount: 7.7 }])
+      portfolio2.holdings.create([{ coin: coin_b, amount: 2.2 },
+                                  { coin: coin_c, amount: 3.3 },
+                                  { coin: coin_d, amount: 4.4 }])
+
+      assets = user.account.assets
+
+      expect(assets.count).to   eq 4
+      expect(assets[coin_a]).to eq 5.5
+      expect(assets[coin_b]).to eq 8.8
+      expect(assets[coin_c]).to eq 11
+      expect(assets[coin_d]).to eq 4.4
+    end
+
+    it 'Returns an empty hash if there are no assets'
+  end
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -79,6 +79,11 @@ RSpec.describe Account, type: :model do
       portfolio2.holdings.create([{ coin: coin_b, amount: 2.2 },
                                   { coin: coin_c, amount: 3.3 },
                                   { coin: coin_d, amount: 4.4 }])
+      other_user = create :user
+      other_portfolio = create :portfolio, account: other_user.account
+      other_portfolio.holdings.create([{ coin: coin_a, amount: 900 },
+                                       { coin: coin_b, amount: 500 },
+                                       { coin: coin_c, amount: 600 }])
 
       assets = user.account.assets
 
@@ -89,6 +94,20 @@ RSpec.describe Account, type: :model do
       expect(assets[coin_d]).to eq 4.4
     end
 
-    it 'Returns an empty hash if there are no assets'
+    it 'return an empty hash if there are no assets in account' do
+      coin_a = create :coin, ticker: 'CNA', rate: 1.11
+      coin_b = create :coin, ticker: 'CNB', rate: 2.22
+      coin_c = create :coin, ticker: 'CNC', rate: 3.33
+      user = create :user
+      other_user = create :user
+      other_portfolio = create :portfolio, account: other_user.account
+      other_portfolio.holdings.create([{ coin: coin_a, amount: 900 },
+                                       { coin: coin_b, amount: 500 },
+                                       { coin: coin_c, amount: 600 }])
+
+      assets = user.account.assets
+
+      expect(assets).to eq({})
+    end
   end
 end


### PR DESCRIPTION
This PR implements a homepage for the account where a table with all assets from an account are presented as a table. This aggregated view sums all assets for the same coin and presents to the user a general balance for every coin added to a portfolio.