### PR TITLE
Refresh rates

### DIFF
--- a/app/models/coin.rb
+++ b/app/models/coin.rb
@@ -6,6 +6,6 @@ class Coin < ApplicationRecord
   validates :rate, numericality: { greater_than_or_equal_to: 0 }
 
   def self.ids_as_string
-    Coin.all.pluck(:api_id).join ','
+    Coin.all.order(:created_at).pluck(:api_id).join ','
   end
 end

--- a/app/models/coin.rb
+++ b/app/models/coin.rb
@@ -4,4 +4,8 @@ class Coin < ApplicationRecord
   validates :name, :api_id, :ticker, :icon, :active, presence: true
   validates :name, :api_id, :ticker, :icon, uniqueness: true
   validates :rate, numericality: { greater_than_or_equal_to: 0 }
+
+  def self.ids_as_string
+    Coin.all.pluck(:api_id).join ','
+  end
 end

--- a/app/services/coin_service.rb
+++ b/app/services/coin_service.rb
@@ -1,10 +1,7 @@
 class CoinService
   def self.import_coins
     res = JSON.parse GeckoService.top_markets, symbolize_names: true
-
-    res.each do |row|
-      Coin.create coin_params row
-    end
+    res.each { |row| Coin.create coin_params row }
   end
 
   def self.refresh_rates
@@ -12,7 +9,7 @@ class CoinService
 
     res.each_pair do |api_id, current_price|
       coin = Coin.find_by(api_id:)
-      coin&.update(rate: current_price[:usd])
+      coin&.update rate: current_price[:usd]
     end
   end
 

--- a/app/services/coin_service.rb
+++ b/app/services/coin_service.rb
@@ -2,9 +2,8 @@ class CoinService
   def self.import_coins
     res = JSON.parse GeckoService.top_markets, symbolize_names: true
 
-    res.each do |r|
-      Coin.create name: r[:name], api_id: r[:id], ticker: r[:symbol].upcase,
-                  icon: r[:image], rate: r[:current_price], active: true
+    res.each do |row|
+      Coin.create coin_params row
     end
   end
 
@@ -16,4 +15,15 @@ class CoinService
       coin&.update(rate: current_price[:usd])
     end
   end
+
+  def self.coin_params(row)
+    {
+      name: row[:name],
+      api_id: row[:id],
+      ticker: row[:symbol].upcase,
+      icon: row[:image],
+      rate: row[:current_price]
+    }
+  end
+  private_class_method :coin_params
 end

--- a/app/services/gecko_service.rb
+++ b/app/services/gecko_service.rb
@@ -2,9 +2,6 @@ class GeckoService
   GECKO_CONSTANTS = Rails.configuration.coingecko_api
 
   def self.top_markets
-    conn = Faraday.new(url: GECKO_CONSTANTS[:base_url],
-                       headers: { 'Content-Type': 'application/json' })
-
     res = conn.get(GECKO_CONSTANTS[:markets_url], {
                      vs_currency: 'usd',
                      order: 'market_cap_desc',
@@ -17,9 +14,6 @@ class GeckoService
   end
 
   def self.prices
-    conn = Faraday.new(url: GECKO_CONSTANTS[:base_url],
-                       headers: { 'Content-Type': 'application/json' })
-
     res = conn.get(GECKO_CONSTANTS[:prices_url],
                    { ids: Coin.ids_as_string,
                      vs_currencies: GECKO_CONSTANTS[:supported_currencies],
@@ -27,4 +21,10 @@ class GeckoService
 
     res.body if res.status == 200
   end
+
+  def self.conn
+    Faraday.new(url: GECKO_CONSTANTS[:base_url],
+                headers: { 'Content-Type': 'application/json' })
+  end
+  private_class_method :conn
 end

--- a/app/services/gecko_service.rb
+++ b/app/services/gecko_service.rb
@@ -1,24 +1,29 @@
 class GeckoService
+  GECKO_CONSTANTS = Rails.configuration.coingecko_api
+
   def self.top_markets
-    conn = Faraday.new(url: 'https://api.coingecko.com',
+    conn = Faraday.new(url: GECKO_CONSTANTS[:base_url],
                        headers: { 'Content-Type': 'application/json' })
 
-    res = conn.get('/api/v3/coins/markets', { vs_currency: 'usd',
-                                              order: 'market_cap_desc',
-                                              per_page: 100,
-                                              price_change_percentage: '24h',
-                                              precision: 8 })
+    res = conn.get(GECKO_CONSTANTS[:markets_url], {
+                     vs_currency: 'usd',
+                     order: 'market_cap_desc',
+                     per_page: 100,
+                     price_change_percentage: '24h',
+                     precision: 8
+                   })
 
     res.body if res.status == 200
   end
 
   def self.prices
-    conn = Faraday.new(url: 'https://api.coingecko.com',
+    conn = Faraday.new(url: GECKO_CONSTANTS[:base_url],
                        headers: { 'Content-Type': 'application/json' })
 
-    res = conn.get('/api/v3/simple/price', { ids: Coin.ids_as_string,
-                                             vs_currencies: 'usd',
-                                             precision: 8 })
+    res = conn.get(GECKO_CONSTANTS[:prices_url],
+                   { ids: Coin.ids_as_string,
+                     vs_currencies: GECKO_CONSTANTS[:supported_currencies],
+                     precision: 8 })
 
     res.body if res.status == 200
   end

--- a/app/services/gecko_service.rb
+++ b/app/services/gecko_service.rb
@@ -2,29 +2,28 @@ class GeckoService
   GECKO_CONSTANTS = Rails.configuration.coingecko_api
 
   def self.conn
-    Faraday.new(url: GECKO_CONSTANTS[:base_url],
-                headers: { 'Content-Type': 'application/json' })
+    Faraday.new url: GECKO_CONSTANTS[:base_url],
+                headers: { 'Content-Type': 'application/json' }
   end
   private_class_method :conn
 
   def self.top_markets
-    res = conn.get(GECKO_CONSTANTS[:markets_url], {
-                     vs_currency: 'usd',
-                     order: 'market_cap_desc',
-                     per_page: 100,
-                     price_change_percentage: '24h',
-                     precision: 8
-                   })
+    res = conn.get GECKO_CONSTANTS[:markets_url],
+                   { vs_currency: GECKO_CONSTANTS[:base_currency],
+                     order: GECKO_CONSTANTS[:order],
+                     per_page: GECKO_CONSTANTS[:limit],
+                     price_change_percentage: GECKO_CONSTANTS[:price_delta],
+                     precision: GECKO_CONSTANTS[:precision] }
 
-    res.body if res.status == 200
+    res.body if res.status == :ok
   end
 
   def self.prices
-    res = conn.get(GECKO_CONSTANTS[:prices_url],
+    res = conn.get GECKO_CONSTANTS[:prices_url],
                    { ids: Coin.ids_as_string,
                      vs_currencies: GECKO_CONSTANTS[:supported_currencies],
-                     precision: 8 })
+                     precision: GECKO_CONSTANTS[:precision] }
 
-    res.body if res.status == 200
+    res.body if res.status == :ok
   end
 end

--- a/app/services/gecko_service.rb
+++ b/app/services/gecko_service.rb
@@ -12,5 +12,14 @@ class GeckoService
     res.body if res.status == 200
   end
 
-  def self.prices; end
+  def self.prices
+    conn = Faraday.new(url: 'https://api.coingecko.com',
+                       headers: { 'Content-Type': 'application/json' })
+
+    res = conn.get('/api/v3/simple/price', { ids: Coin.ids_as_string,
+                                             vs_currencies: 'usd',
+                                             precision: 8 })
+
+    res.body if res.status == 200
+  end
 end

--- a/app/services/gecko_service.rb
+++ b/app/services/gecko_service.rb
@@ -1,6 +1,12 @@
 class GeckoService
   GECKO_CONSTANTS = Rails.configuration.coingecko_api
 
+  def self.conn
+    Faraday.new(url: GECKO_CONSTANTS[:base_url],
+                headers: { 'Content-Type': 'application/json' })
+  end
+  private_class_method :conn
+
   def self.top_markets
     res = conn.get(GECKO_CONSTANTS[:markets_url], {
                      vs_currency: 'usd',
@@ -21,10 +27,4 @@ class GeckoService
 
     res.body if res.status == 200
   end
-
-  def self.conn
-    Faraday.new(url: GECKO_CONSTANTS[:base_url],
-                headers: { 'Content-Type': 'application/json' })
-  end
-  private_class_method :conn
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,7 @@ module CryptoTracker
         request_specs: false
       g.fixture_replacement :factory_bot, dir: "spec/factories"
     end
+
+    config.coingecko_api = config_for(:coingecko_api)
   end
 end

--- a/config/coingecko_api.yml
+++ b/config/coingecko_api.yml
@@ -1,0 +1,6 @@
+shared:
+  base_url: 'https://api.coingecko.com'
+  markets_url: '/api/v3/coins/markets'
+  prices_url: '/api/v3/simple/price'
+  
+  supported_currencies: 'usd'

--- a/config/coingecko_api.yml
+++ b/config/coingecko_api.yml
@@ -1,6 +1,11 @@
 shared:
-  base_url: 'https://api.coingecko.com'
+  base_url:    'https://api.coingecko.com'
   markets_url: '/api/v3/coins/markets'
-  prices_url: '/api/v3/simple/price'
+  prices_url:  '/api/v3/simple/price'
   
+  base_currency:        'usd'
+  order:                'market_cap_desc'
+  limit:                 100
+  price_delta:          '24h'
   supported_currencies: 'usd'
+  precision:             8

--- a/spec/models/coin_spec.rb
+++ b/spec/models/coin_spec.rb
@@ -86,4 +86,22 @@ RSpec.describe Coin, type: :model do
       expect(coin.errors.full_messages).to include 'Active can\'t be blank'
     end
   end
+
+  describe '.ids_as_string' do
+    it 'Returns string with comma separated api_ids of every saved coin' do
+      coin_a       = create :coin, api_id: 'coin_a'
+      coin_b       = create :coin, api_id: 'coin_b'
+      coin_c       = create :coin, api_id: 'coin_c'
+      unsaved_coin = build  :coin, api_id: 'unsaved_coin'
+
+      ids_string = Coin.ids_as_string
+
+      expect(ids_string).to     include coin_a.api_id, coin_b.api_id, coin_c.api_id
+      expect(ids_string).not_to include unsaved_coin.api_id
+    end
+
+    it 'returns an empty string if there are no coins in database' do
+      expect(Coin.ids_as_string).to eq ''
+    end
+  end
 end

--- a/spec/services/gecko_service_spec.rb
+++ b/spec/services/gecko_service_spec.rb
@@ -19,4 +19,24 @@ RSpec.describe GeckoService do
       )
     end
   end
+
+  describe '.prices' do
+    it 'Calls Coin Gecko API\'s price endpoint with api_id for databse coins' do
+      create :coin, api_id: 'coin_a'
+      create :coin, api_id: 'coin_b'
+      create :coin, api_id: 'coin_c'
+
+      connection_spy = spy Faraday::Connection
+      stub_const 'Faraday::Connection', connection_spy
+
+      GeckoService.prices
+
+      expect(connection_spy).to have_received(:get).with(
+        '/api/v3/simple/price',
+        ids: 'coin_a,coin_b,coin_c',
+        vs_currencies: 'usd',
+        precision: 8
+      )
+    end
+  end
 end


### PR DESCRIPTION
This PR implements the rates refresh feature. This is done by querying the Coin Gecko API for updated rates for every coin saved to the database, then updating them.

The Coin Gecko API addresses and parameters for the request were all centralized into a YAML configuration file.

So far, the only way to actually update the rates is via the console. The plan is to add a cron job to query the database periodically and always keep the rates updated.