### PR TITLE
Portfolio layout

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -4,6 +4,10 @@
 
 @layer components {
   .btn-primary {
-    @apply px-2 py-1 font-semibold text-sm bg-slate-800 text-slate-100 rounded-md shadow hover:bg-slate-950;
+    @apply px-5 py-2 font-semibold text-sm bg-slate-800 text-slate-100 rounded-md shadow hover:bg-slate-950;
+  }
+  
+  .btn-secondary {
+    @apply px-4 py-1 h-7 font-semibold text-sm bg-slate-400 text-slate-50 rounded-md shadow hover:bg-slate-800 hover:text-slate-100;
   }
 }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  .btn-primary {
+    @apply p-1 border border-slate-800 rounded hover:bg-slate-800 hover:text-white;
+  }
+}

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -8,6 +8,6 @@
   }
   
   .btn-secondary {
-    @apply px-4 py-1 h-7 font-semibold text-sm bg-slate-400 text-slate-50 rounded-md shadow hover:bg-slate-800 hover:text-slate-100;
+    @apply px-4 py-1 h-7 font-semibold text-sm bg-slate-500 text-slate-50 rounded-md shadow hover:bg-slate-800 hover:text-slate-100;
   }
 }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -4,6 +4,6 @@
 
 @layer components {
   .btn-primary {
-    @apply p-1 border border-slate-800 rounded hover:bg-slate-800 hover:text-white;
+    @apply px-2 py-1 font-semibold text-sm bg-slate-800 text-slate-100 rounded-md shadow hover:bg-slate-950;
   }
 }

--- a/app/javascript/controllers/holdings_controller.js
+++ b/app/javascript/controllers/holdings_controller.js
@@ -4,16 +4,16 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["priceChange"];
   static values  = {
-    delta: Number
+    change: Number
   }
   
   connect() {
   }
   
-  priceChangeTargetConnected() {    
-    if (this.deltaValue > 0) {
+  priceChangeTargetConnected() {
+    if (this.changeValue > 0) {
       this.priceChangeTarget.className += " text-green-700";
-    } else if (this.deltaValue < 0) {
+    } else if (this.changeValue < 0) {
       this.priceChangeTarget.className += " text-red-700";
     } else {
       this.priceChangeTarget.className += " text-slate-500";

--- a/app/javascript/controllers/holdings_controller.js
+++ b/app/javascript/controllers/holdings_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="holdings"
+export default class extends Controller {
+  static targets = ["priceChange"];
+  static values  = {
+    delta: Number
+  }
+  
+  connect() {
+  }
+  
+  priceChangeTargetConnected() {    
+    if (this.deltaValue > 0) {
+      this.priceChangeTarget.className += " text-green-700";
+    } else if (this.deltaValue < 0) {
+      this.priceChangeTarget.className += " text-red-700";
+    } else {
+      this.priceChangeTarget.className += " text-slate-500";
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import HoldingsController from "./holdings_controller"
+application.register("holdings", HoldingsController)

--- a/app/models/holding.rb
+++ b/app/models/holding.rb
@@ -18,4 +18,8 @@ class Holding < ApplicationRecord
   def withdraw(amount)
     self.amount -= amount if amount.positive? && amount <= self.amount
   end
+
+  def proportion
+    (value / portfolio.total_balance * 100).round 2
+  end
 end

--- a/app/views/holdings/_holding.html.erb
+++ b/app/views/holdings/_holding.html.erb
@@ -1,37 +1,35 @@
-<tr>
-  <td class="p-1">
-    <div class="">
-      <img src="<%= holding.coin.icon %>%>"
-          alt="<%= holding.coin.api_id %>%>_icon"
-          width="25">
+<%= link_to [:edit, holding] do %>
+  <div class="grid grid-cols-3 gap-y-5 items-center">
+    <div class="p-1 flex flex-row gap-2 items-center">
+      <div>
+        <img src="<%= holding.coin.icon %>%>"
+            alt="<%= holding.coin.api_id %>%>_icon"
+            width="30">
+      </div>
       <div>
         <p class="font-semibold text-base">
           <%= holding.ticker %>
         </p>
+        <p class="text-sm">
+          <%= number_to_currency holding.rate.round(2) %>
+        </p>
         <p class="text-xs">
-          <%= number_to_currency holding.rate.round(2) %> 
-          (<%= number_to_percentage holding.price_change, precision: 2 %>)
+          <%= number_to_percentage holding.price_change, precision: 2 %>
         </p>
       </div>
     </div>
-  </td>
-  
-  <td class="p-1">
-    <p>
-      <%= number_to_currency holding.value.round(2) %>
-    </p>
-    <p  class="text-xs">
-      <%= holding.amount.round 5 %>
-    </p>
-  </td>
-  <td class="p-1">
-    <%= number_to_percentage holding.proportion,
-                             precision: 2 %>
-  </td>
-  
-  <td class="p-1">
-    <%= link_to 'Manage', 
-                [:edit, holding],
-                class: 'btn-primary' %>
-  </td>
-</tr>
+
+    <div class="p-1">
+      <p>
+        <%= number_to_currency holding.value.round(2) %>
+      </p>
+      <p  class="text-xs">
+        <%= holding.amount.round 5 %>
+      </p>
+    </div>
+    <div class="p-1">
+      <%= number_to_percentage holding.proportion,
+                               precision: 2 %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/holdings/_holding.html.erb
+++ b/app/views/holdings/_holding.html.erb
@@ -1,7 +1,7 @@
 <%= link_to [:edit, holding] do %>
   <div class="p-1 grid grid-cols-5 items-center hover:bg-slate-200"
        data-controller="holdings"
-       data-holdings-delta-value="<%= holding.price_change %>">
+       data-holdings-change-value="<%= holding.price_change %>">
     <div class="col-span-2 p-1 flex flex-row gap-3 items-baseline">
       <div class="self-center">
         <img src="<%= holding.coin.icon %>%>"
@@ -35,4 +35,6 @@
                                precision: 2 %>
     </div>
   </div>
+  
+  <hr>
 <% end %>

--- a/app/views/holdings/_holding.html.erb
+++ b/app/views/holdings/_holding.html.erb
@@ -1,26 +1,37 @@
 <tr>
-  <div>
-    <td class="p-1">
+  <td class="p-1">
+    <div class="">
       <img src="<%= holding.coin.icon %>%>"
           alt="<%= holding.coin.api_id %>%>_icon"
           width="25">
-      <%= holding.ticker %>
-      <%= number_to_currency holding.rate.round(2) %>
-      <%= number_to_percentage holding.price_change,
-                              precision: 2 %>
-    </td>
-    <td class="p-1">
+      <div>
+        <p class="font-semibold text-base">
+          <%= holding.ticker %>
+        </p>
+        <p class="text-xs">
+          <%= number_to_currency holding.rate.round(2) %> 
+          (<%= number_to_percentage holding.price_change, precision: 2 %>)
+        </p>
+      </div>
+    </div>
+  </td>
+  
+  <td class="p-1">
+    <p>
       <%= number_to_currency holding.value.round(2) %>
+    </p>
+    <p  class="text-xs">
       <%= holding.amount.round 5 %>
-    </td>
-    <td class="p-1">
-      <%= number_to_percentage holding.proportion,
-                              precision: 2 %>
-    </td>
-    <td class="p-1">
-      <%= link_to 'Manage', 
-                  [:edit, holding],
-                  class: 'btn-primary' %>
-    </td>
-  </div>
+    </p>
+  </td>
+  <td class="p-1">
+    <%= number_to_percentage holding.proportion,
+                             precision: 2 %>
+  </td>
+  
+  <td class="p-1">
+    <%= link_to 'Manage', 
+                [:edit, holding],
+                class: 'btn-primary' %>
+  </td>
 </tr>

--- a/app/views/holdings/_holding.html.erb
+++ b/app/views/holdings/_holding.html.erb
@@ -1,29 +1,29 @@
 <%= link_to [:edit, holding] do %>
-  <div class="grid grid-cols-3 gap-y-5 items-center">
-    <div class="p-1 flex flex-row gap-2 items-center">
-      <div>
+  <div class="p-1 grid grid-cols-5 items-center hover:bg-slate-200">
+    <div class="col-span-2 p-1 flex flex-row gap-3 items-baseline">
+      <div class="self-center">
         <img src="<%= holding.coin.icon %>%>"
             alt="<%= holding.coin.api_id %>%>_icon"
-            width="30">
+            class="bg-slate-50 rounded-full size-8 shadow">
       </div>
-      <div>
-        <p class="font-semibold text-base">
-          <%= holding.ticker %>
-        </p>
+      <div class="flex flex-col flex-1">
+        <div class="text-base font-semibold">
+          <p><%= holding.ticker %></p>
+        </div>
         <p class="text-sm">
           <%= number_to_currency holding.rate.round(2) %>
         </p>
-        <p class="text-xs">
+        <p class="text-xs font-light">
           <%= number_to_percentage holding.price_change, precision: 2 %>
         </p>
       </div>
     </div>
 
-    <div class="p-1">
-      <p>
+    <div class="p-1 col-span-2 ps-6">
+      <p class="text-lg font-bold text-green-800">
         <%= number_to_currency holding.value.round(2) %>
       </p>
-      <p  class="text-xs">
+      <p class="text-xs text-gray-600">
         <%= holding.amount.round 5 %>
       </p>
     </div>

--- a/app/views/holdings/_holding.html.erb
+++ b/app/views/holdings/_holding.html.erb
@@ -1,22 +1,26 @@
 <tr>
-  <td class="p-1">
-    <img src="<%= holding.coin.icon %>%>" 
-         alt="<%= holding.coin.api_id %>%>_icon"
-         width="25">
-    <%= holding.ticker %>
-    <%= number_to_currency holding.rate.round(2) %>
-    <%= number_to_percentage holding.price_change,
-                             precision: 2 %>
-  </td>
-  <td class="p-1">
-    <%= number_to_currency holding.value.round(2) %>
-    <%= holding.amount.round 5 %>
-  </td>
-  <td class="p-1">
-    <%= number_to_percentage holding.proportion,
-                             precision: 2 %>
-  </td>
-  <td class="p-1">
-    <%= link_to 'Manage', [:edit, holding] %>
-  </td>
+  <div>
+    <td class="p-1">
+      <img src="<%= holding.coin.icon %>%>"
+          alt="<%= holding.coin.api_id %>%>_icon"
+          width="25">
+      <%= holding.ticker %>
+      <%= number_to_currency holding.rate.round(2) %>
+      <%= number_to_percentage holding.price_change,
+                              precision: 2 %>
+    </td>
+    <td class="p-1">
+      <%= number_to_currency holding.value.round(2) %>
+      <%= holding.amount.round 5 %>
+    </td>
+    <td class="p-1">
+      <%= number_to_percentage holding.proportion,
+                              precision: 2 %>
+    </td>
+    <td class="p-1">
+      <%= link_to 'Manage', 
+                  [:edit, holding],
+                  class: 'btn-primary' %>
+    </td>
+  </div>
 </tr>

--- a/app/views/holdings/_holding.html.erb
+++ b/app/views/holdings/_holding.html.erb
@@ -1,18 +1,18 @@
 <%= link_to [:edit, holding] do %>
-  <div class="p-1 grid grid-cols-5 items-center hover:bg-slate-200"
+  <div class="p-1 grid grid-cols-5 items-start hover:bg-slate-200"
        data-controller="holdings"
        data-holdings-change-value="<%= holding.price_change %>">
     <div class="col-span-2 p-1 flex flex-row gap-3 items-baseline">
       <div class="self-center">
         <img src="<%= holding.coin.icon %>%>"
             alt="<%= holding.coin.api_id %>%>_icon"
-            class="bg-slate-50 rounded-full size-8 shadow">
+            class="bg-slate-50 rounded-full size-9 shadow">
       </div>
       <div class="flex flex-col flex-1">
-        <div class="text-base font-semibold">
+        <div class="text-lg font-semibold">
           <p><%= holding.ticker %></p>
         </div>
-        <p class="text-sm">
+        <p class="text-xs text-slate-600">
           <%= number_to_currency holding.rate.round(2) %>
         </p>
         <p class="text-xs"
@@ -26,11 +26,11 @@
       <p class="text-lg font-bold text-green-800">
         <%= number_to_currency holding.value.round(2) %>
       </p>
-      <p class="text-xs text-gray-600">
+      <p class="text-xs text-slate-600">
         <%= holding.amount.round 5 %>
       </p>
     </div>
-    <div class="p-1">
+    <div class="p-1 text-lg">
       <%= number_to_percentage holding.proportion,
                                precision: 2 %>
     </div>

--- a/app/views/holdings/_holding.html.erb
+++ b/app/views/holdings/_holding.html.erb
@@ -1,12 +1,12 @@
 <%= link_to [:edit, holding] do %>
-  <div class="p-1 grid grid-cols-5 items-start hover:bg-slate-200"
+  <div class="py-2 px-2 grid grid-cols-5 items-start hover:shadow-md hover:bg-slate-200"
        data-controller="holdings"
        data-holdings-change-value="<%= holding.price_change %>">
     <div class="col-span-2 p-1 flex flex-row gap-3 items-baseline">
       <div class="self-center">
         <img src="<%= holding.coin.icon %>%>"
             alt="<%= holding.coin.api_id %>%>_icon"
-            class="bg-slate-50 rounded-full size-9 shadow">
+            class="bg-slate-50 rounded-full size-9 shadow-md">
       </div>
       <div class="flex flex-col flex-1">
         <div class="text-lg font-semibold">
@@ -30,7 +30,7 @@
         <%= holding.amount.round 5 %>
       </p>
     </div>
-    <div class="p-1 text-lg">
+    <div class="p-1 text-lg text-slate-600 font-semibold text-end">
       <%= number_to_percentage holding.proportion,
                                precision: 2 %>
     </div>

--- a/app/views/holdings/_holding.html.erb
+++ b/app/views/holdings/_holding.html.erb
@@ -1,5 +1,7 @@
 <%= link_to [:edit, holding] do %>
-  <div class="p-1 grid grid-cols-5 items-center hover:bg-slate-200">
+  <div class="p-1 grid grid-cols-5 items-center hover:bg-slate-200"
+       data-controller="holdings"
+       data-holdings-delta-value="<%= holding.price_change %>">
     <div class="col-span-2 p-1 flex flex-row gap-3 items-baseline">
       <div class="self-center">
         <img src="<%= holding.coin.icon %>%>"
@@ -13,7 +15,8 @@
         <p class="text-sm">
           <%= number_to_currency holding.rate.round(2) %>
         </p>
-        <p class="text-xs font-light">
+        <p class="text-xs"
+           data-holdings-target="priceChange">
           <%= number_to_percentage holding.price_change, precision: 2 %>
         </p>
       </div>

--- a/app/views/holdings/_holding.html.erb
+++ b/app/views/holdings/_holding.html.erb
@@ -1,20 +1,22 @@
 <tr>
-  <td class="border p-1">
+  <td class="p-1">
+    <img src="<%= holding.coin.icon %>%>" 
+         alt="<%= holding.coin.api_id %>%>_icon"
+         width="25">
     <%= holding.ticker %>
-  </td>
-  <td class="border p-1">
     <%= number_to_currency holding.rate.round(2) %>
+    <%= number_to_percentage holding.price_change,
+                             precision: 2 %>
   </td>
-  <td class="border p-1">
-    <%= number_to_percentage holding.price_change, precision: 2 %>
-  </td>
-  <td class="border p-1">
-    <%= holding.amount.round 4 %>
-  </td>
-  <td class="border p-1">
+  <td class="p-1">
     <%= number_to_currency holding.value.round(2) %>
+    <%= holding.amount.round 5 %>
   </td>
-  <td class="border p-1">
+  <td class="p-1">
+    <%= number_to_percentage holding.proportion,
+                             precision: 2 %>
+  </td>
+  <td class="p-1">
     <%= link_to 'Manage', [:edit, holding] %>
   </td>
 </tr>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="container mx-auto p-2">
+  <body class="container mx-auto p-2 bg-slate-100 text-slate-800">
     
     <div>
       <% if flash[:notice] %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body>
+  <body class="container mx-auto p-2">
     
     <div>
       <% if flash[:notice] %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="container mx-auto p-2 bg-slate-100 text-slate-800">
+  <body class="container mx-auto p-2 text-slate-800 bg-slate-100">
     
     <div>
       <% if flash[:notice] %>

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -23,18 +23,17 @@
   </div>
   
   <hr class="my-3">
+   
+  <div id="table-header" 
+       class="grid grid-cols-3 mb-2">
+    <div class="text-sm">Asset</div>
+    <div class="text-sm">Balance</div>
+    <div class="text-sm">Proportion</div>
+  </div>
   
-  <table class="table-auto">
-    <thead>
-      <trow>
-        <th class="font-normal text-base text-slate-700">Asset</th>
-        <th class="font-normal text-base text-slate-700">Balance</th>
-        <th class="font-normal text-base text-slate-700">Proportion</th>
-        <th class="font-normal text-base text-slate-700"></th>
-      </trow>
-    </thead>
-    <tbody>
-      <%= render @holdings %>
-    </tbody>
-  </table>
+  <hr>
+    
+  <div id="table-body">
+    <%= render @holdings %>
+  </div>
 </section>

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -14,15 +14,13 @@
     <%= link_to 'New Holding', new_portfolio_holding_path(@portfolio) %>
   </div>
   
-  <table class="table-auto border-collapse border">
+  <table class="table-auto">
     <thead>
       <trow>
-        <th class="border">Asset</th>
-        <th class="border">Rate</th>
-        <th class="border">Change 24h</th>
-        <th class="border">Amount</th>
-        <th class="border">USD</th>
-        <th class="border"></th>
+        <th class="">Asset</th>
+        <th class="">Balance</th>
+        <th class="">Proportion</th>
+        <th class=""></th>
       </trow>
     </thead>
     <tbody>

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -1,16 +1,20 @@
-<%= link_to 'Back', portfolios_path %>
+<%= link_to 'Back', 
+            portfolios_path,
+            class: 'btn-primary' %>
 
 <section>
-  <div class="header">
-    <h1><%= @portfolio.name %></h1>
-    <%= link_to 'Manage', [:edit, @portfolio] %>
+  <div class="mb-3">
+    <h1 class="text-4xl font-semibold">
+      <%= @portfolio.name %>
+    </h1>
+    <h2 class="text-lg font-lg">
+      Total Balance: <%= number_to_currency @portfolio.total_balance %>
+    </h2>
   </div>
   
-  <h3>
-    Total Balance: <%= number_to_currency @portfolio.total_balance %>
-  </h3>
   
-  <div>
+  <div class="mb-3">
+    <%= link_to 'Manage', [:edit, @portfolio] %>
     <%= link_to 'New Holding', new_portfolio_holding_path(@portfolio) %>
   </div>
   

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -1,12 +1,14 @@
-<%= link_to 'Back', 
-            portfolios_path,
-            class: 'btn-primary' %>
 
 <section>
   <div class="my-3">
-    <h1 class="text-4xl font-semibold">
-      <%= @portfolio.name %>
-    </h1>
+    <div class="flex flex-row justify-between items-center">
+      <h1 class="text-4xl font-semibold">
+        <%= @portfolio.name %>
+      </h1>
+      <%= link_to 'Back',
+                  portfolios_path,
+                  class: 'btn-secondary' %>
+    </div>
     <h2 class="text-xl">
       Total Balance: <span class="font-bold text-green-800"><%= number_to_currency @portfolio.total_balance %></span>
     </h2>

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -7,13 +7,14 @@
     <h1 class="text-4xl font-semibold">
       <%= @portfolio.name %>
     </h1>
-    <h2 class="text-lg font-lg">
-      Total Balance: <span class="font-semibold text-green-800"><%= number_to_currency @portfolio.total_balance %></span>
+    <h2 class="text-xl">
+      Total Balance: <span class="font-bold text-green-800"><%= number_to_currency @portfolio.total_balance %></span>
     </h2>
   </div>
   
   
-  <div class="">
+  <div id="buttons"
+       class="my-6">
     <%= link_to 'Manage', 
                 [:edit, @portfolio],
                 class: 'btn-primary' %>
@@ -21,13 +22,11 @@
                 [:new, @portfolio, :holding],
                 class: 'btn-primary' %>
   </div>
-  
-  <hr class="my-3">
-   
+     
   <div id="table-header" 
-       class="grid grid-cols-3 mb-2">
-    <div class="text-sm">Asset</div>
-    <div class="text-sm">Balance</div>
+       class="grid grid-cols-5 mt-7 mb-3">
+    <div class="text-sm col-span-2">Asset</div>
+    <div class="text-sm col-span-2 ps-6">Balance</div>
     <div class="text-sm">Proportion</div>
   </div>
   

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -26,8 +26,8 @@
   </div>
      
   <div id="table-header" 
-       class="grid grid-cols-5 mt-7 mb-3">
-    <div class="text-sm col-span-2">Asset</div>
+       class="grid grid-cols-5 mt-7 mb-3 text-slate-600 px-2">
+    <div class="text-sm col-span-2 ps-14">Asset</div>
     <div class="text-sm col-span-2 ps-6">Balance</div>
     <div class="text-sm">Proportion</div>
   </div>

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -3,28 +3,34 @@
             class: 'btn-primary' %>
 
 <section>
-  <div class="mb-3">
+  <div class="my-3">
     <h1 class="text-4xl font-semibold">
       <%= @portfolio.name %>
     </h1>
     <h2 class="text-lg font-lg">
-      Total Balance: <%= number_to_currency @portfolio.total_balance %>
+      Total Balance: <span class="font-semibold text-green-800"><%= number_to_currency @portfolio.total_balance %></span>
     </h2>
   </div>
   
   
-  <div class="mb-3">
-    <%= link_to 'Manage', [:edit, @portfolio] %>
-    <%= link_to 'New Holding', new_portfolio_holding_path(@portfolio) %>
+  <div class="">
+    <%= link_to 'Manage', 
+                [:edit, @portfolio],
+                class: 'btn-primary' %>
+    <%= link_to 'New Holding', 
+                [:new, @portfolio, :holding],
+                class: 'btn-primary' %>
   </div>
+  
+  <hr class="my-3">
   
   <table class="table-auto">
     <thead>
       <trow>
-        <th class="">Asset</th>
-        <th class="">Balance</th>
-        <th class="">Proportion</th>
-        <th class=""></th>
+        <th class="font-normal text-base text-slate-700">Asset</th>
+        <th class="font-normal text-base text-slate-700">Balance</th>
+        <th class="font-normal text-base text-slate-700">Proportion</th>
+        <th class="font-normal text-base text-slate-700"></th>
       </trow>
     </thead>
     <tbody>

--- a/spec/models/holding_spec.rb
+++ b/spec/models/holding_spec.rb
@@ -82,4 +82,20 @@ RSpec.describe Holding, type: :model do
       expect(holding.amount).to eq 0.0
     end
   end
+
+  describe '#proportion' do
+    it 'Returns the holding\'s USD proportion in relation to portfolio total value' do
+      coin_a    = create :coin, rate: 1.11
+      coin_b    = create :coin, rate: 2.22
+      coin_c    = create :coin, rate: 3.33
+      portfolio = create :portfolio
+      holding_a = create :holding, portfolio:, coin: coin_a, amount: 5
+      holding_b = create :holding, portfolio:, coin: coin_b, amount: 4
+      holding_c = create :holding, portfolio:, coin: coin_c, amount: 3
+
+      expect(holding_a.proportion).to eq 22.73
+      expect(holding_b.proportion).to eq 36.36
+      expect(holding_c.proportion).to eq 40.91
+    end
+  end
 end


### PR DESCRIPTION
This PR implements the first basic layout for the portfolio view. With it was created two button styles (primary and secondary) in the Tailwind config file for easy reuse in the application.

Below an example of the design:

![image](https://github.com/fredericomozzato/crypto_tracker/assets/93487157/81ba8d22-fa80-42e2-8635-5ff43c8dc0a3)

It has dynamic style for the price change values using Stimulus to color it green when in positive ranges and red when in negative ranges.

The design is still optimized for mobile and small screens, but in the future the support for bigger screens will be implemented too.