### PR TITLE
Fix N+1 query

### DIFF
--- a/app/controllers/portfolios_controller.rb
+++ b/app/controllers/portfolios_controller.rb
@@ -25,6 +25,7 @@ class PortfoliosController < ApplicationController
 
   def show
     @holdings = @portfolio.holdings
+                          .includes(:coin)
                           .sort_by(&:value)
                           .reverse
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -13,7 +13,9 @@ class Account < ApplicationRecord
   end
 
   def assets
-    holdings.group(:coin).sum(:amount)
+    holdings.includes(:coin)
+            .group(:coin)
+            .sum(:amount)
   end
 
   private


### PR DESCRIPTION
Use the `includes` method to load resources while performing the first query. This was implemented in the `PortfoliosController` and in the `Account#assets` method. Both cases select holdings from the database and include the respective coins to avoid extra requests.