### PR TITLE
chore: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v2
 
       - name: Test
         run: go test -race -coverprofile=coverage.out ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Install gofumpt
+        run: go install mvdan.cc/gofumpt@latest
+
+      - name: Check formatting
+        run: |
+          unformatted=$(gofumpt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not formatted:"
+            echo "$unformatted"
+            echo "Run 'gofumpt -w .' to fix."
+            exit 1
+          fi
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+
+      - name: Test
+        run: go test -race -coverprofile=coverage.out ./...
+
+      - name: Vulnerability check
+        uses: golang/govulncheck-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,21 +7,16 @@ on:
     branches: [main]
 
 jobs:
-  check:
-    name: Check
+  fmt:
+    name: Format
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.24"
-
       - name: Install gofumpt
         run: go install mvdan.cc/gofumpt@latest
-
       - name: Check formatting
         run: |
           unformatted=$(gofumpt -l .)
@@ -32,13 +27,35 @@ jobs:
             exit 1
           fi
 
-      - name: Lint
-        uses: golangci/golangci-lint-action@v7
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+      - uses: golangci/golangci-lint-action@v7
         with:
           version: v2.11.4
 
-      - name: Test
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+      - name: Run tests
         run: go test -race -coverprofile=coverage.out ./...
 
-      - name: Vulnerability check
-        uses: golang/govulncheck-action@v1
+  vuln:
+    name: Vulnerability check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+      - uses: golang/govulncheck-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Install gofumpt
         run: go install mvdan.cc/gofumpt@latest
@@ -33,7 +33,7 @@ jobs:
           fi
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.11.4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v2
+          version: v2.11.4
 
       - name: Test
         run: go test -race -coverprofile=coverage.out ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,12 +5,8 @@ linters:
     - staticcheck
     - gocritic
     - noctx
-
-linters-settings:
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - style
-
-issues:
-  exclude-use-default: false
+  settings:
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - style


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with four parallel jobs: **Format**, **Lint**, **Test**, **Vulnerability check**
- Each job appears as a named check in GitHub, making it immediately clear which step failed
- Pins golangci-lint to v2.11.4 via `golangci-lint-action@v7` to match the v2 config schema in `.golangci.yml`
- Migrates `.golangci.yml` to the v2 schema (`linters.settings`, removed deprecated fields)

## Test Plan
- [ ] CI / Format passes (gofumpt check)
- [ ] CI / Lint passes (golangci-lint with errcheck, staticcheck, gocritic, noctx)
- [ ] CI / Test passes (race detector enabled)
- [ ] CI / Vulnerability check passes (govulncheck)