### PR TITLE
feat(slice-004): auto-refresh + status bar

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -16,7 +16,6 @@ the feature branch, implement with TDD, and hand off to the user for manual test
 
 ```dot
 digraph build {
-    "Load context" -> "Find IN_PROGRESS slice";
     "Find IN_PROGRESS slice" -> "Read issue plan";
     "Read issue plan" -> "Survey codebase";
     "Survey codebase" -> "Plan blockers?" [label="validate"];
@@ -38,25 +37,19 @@ digraph build {
 
 ## Steps
 
-### 1. Load context
-
-Read these two files before doing anything:
-- `docs/PRD.md` — feature specs, UI layout, keyboard map, data model
-- `docs/ARCHITECTURE.md` — conventions every file must follow
-
-### 2. Find the IN_PROGRESS slice
+### 1. Find the IN_PROGRESS slice
 
 Read `docs/roadmap.md`. Find the **single** section with `STATUS: IN_PROGRESS`.
 Note the slice number, name, branch name, and any **IMPORTANT** constraint blocks.
 
 If no slice is `IN_PROGRESS`, stop and tell the user to run `/refine` first.
 
-### 3. Read the issue plan
+### 2. Read the issue plan
 
 Open `docs/issues/NNN-kebab-case-name.md` (matching the IN_PROGRESS slice).
 Read the **entire** file — context, scope, file-by-file plan, implementation order, and verification commands.
 
-### 4. Survey the codebase
+### 3. Survey the codebase
 
 Read every file the plan mentions as "modify". Read the existing test files to understand
 established patterns. Read public interfaces the slice must satisfy.
@@ -64,7 +57,7 @@ established patterns. Read public interfaces the slice must satisfy.
 Goal: confirm the plan's type signatures, import paths, and function names are still
 accurate given the current code.
 
-### 5. Validate the plan
+### 4. Validate the plan
 
 Before touching any code, check for:
 
@@ -75,7 +68,10 @@ Before touching any code, check for:
 If any issue is found, describe it clearly and ask the user how to resolve it.
 **Do not begin implementation until the plan is fully understood and sound.**
 
-### 6. Checkout the feature branch
+If the plan has a genuine gap that requires consulting product intent, read the relevant
+section of `docs/PRD.md` on demand — do not read the whole document speculatively.
+
+### 5. Checkout the feature branch
 
 The branch name is in the issue frontmatter: `branch: feat/NNN-kebab-case-name`.
 
@@ -89,7 +85,7 @@ git checkout feat/NNN-kebab-case-name 2>/dev/null || git checkout -b feat/NNN-ke
 
 **Never implement on `main`.** If already on the correct feature branch, proceed.
 
-### 7. Implement with TDD
+### 6. Implement with TDD
 
 Follow the plan's **Implementation order** section exactly — step by step, in the numbered
 sequence. Do not reorder steps.
@@ -110,7 +106,7 @@ git commit -m "feat(slice-NNN): <short description of step>"
 
 Keep commits atomic — one logical change per commit.
 
-**Architecture non-negotiables** (from CLAUDE.md / ARCHITECTURE.md):
+**Architecture non-negotiables** (from CLAUDE.md):
 - `ctx context.Context` is the first parameter of every I/O function
 - UI layer depends on `store.Store` interface, never on `*sql.DB`
 - All side effects returned as `tea.Cmd`; no goroutines inside handlers
@@ -118,7 +114,7 @@ Keep commits atomic — one logical change per commit.
 - Error wrapping: `fmt.Errorf("outer: %w", err)`
 - Tests: real SQLite via `t.TempDir()`; `httptest.NewServer` for API fakes
 
-### 8. Final quality check
+### 7. Final quality check
 
 Once all steps are implemented:
 
@@ -130,14 +126,27 @@ make build   # binary must compile cleanly
 If anything fails, fix it before proceeding. Do not declare the build complete with
 failing checks.
 
-### 9. Update roadmap and issue
+### 8. Update roadmap and issue
+
+> **CRITICAL — read before touching any status field:**
+>
+> Set status to **`IN_REVIEW`** / **`in_review`**. Never `DONE` / `done`.
+>
+> `DONE` is set exclusively by the user or the `/qa` skill after manual verification.
+> If you write `DONE` here you have violated the workflow. There is no exception.
 
 1. In `docs/roadmap.md`, change the slice's `STATUS: IN_PROGRESS` → `STATUS: IN_REVIEW`.
 2. In the issue file frontmatter, change `status: in_progress` → `status: in_review`.
 
-**Do NOT set `STATUS: DONE`.** The `done` status is only set by an explicit user instruction or a dedicated review agent after manual verification passes.
+**Red flags — if you are about to write any of these, stop:**
+- `STATUS: DONE`
+- `status: done`
+- "marking as complete"
+- "marking as done"
 
-### 10. Prompt the user to test
+The correct and only values after `/build` are `IN_REVIEW` (roadmap) and `in_review` (issue frontmatter).
+
+### 9. Prompt the user to test
 
 Present a brief handoff message:
 

--- a/docs/issues/004-auto-refresh-status-bar.md
+++ b/docs/issues/004-auto-refresh-status-bar.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: done
 branch: feat/004-auto-refresh-status-bar
 ---
 
@@ -28,7 +28,7 @@ What's missing for Slice 4:
 From roadmap bullets:
 - 5 s ticker → checks if 60 s elapsed → fires `cmdRefresh` via `/simple/price`
 - Manual refresh with `r` (no-op if already refreshing) — already implemented, just wired to status bar
-- Status bar: `synced Xs ago` / `refreshing...` / `error: <message>` / `loading...`
+- Status bar: `Synced` (green) / `Stale` (yellow, > 5 min since last refresh) / `Refreshing` (gray) / `error: <message>` (red) / `loading...` (gray)
 - Error propagation via typed `errMsg`, non-fatal — keeps table usable with stale data
 - **TDD:** tick/refresh state transitions, error display logic
 
@@ -103,11 +103,16 @@ case pricesUpdatedMsg:
     m.lastRefreshed = time.Now()
 ```
 
-New `statusRight()` helper (priority: refreshing > error > loading > synced):
+Constant for stale detection:
+```go
+const staleThreshold = 5 * time.Minute
+```
+
+`statusRight()` helper (priority: refreshing > error > loading > stale > synced):
 ```go
 func (m AppModel) statusRight() string {
     if m.refreshing {
-        return "refreshing..."
+        return "Refreshing"
     }
     if m.lastErr != "" {
         return "error: " + m.lastErr
@@ -115,31 +120,33 @@ func (m AppModel) statusRight() string {
     if m.lastRefreshed.IsZero() {
         return "loading..."
     }
-    elapsed := time.Since(m.lastRefreshed)
-    switch {
-    case elapsed < time.Minute:
-        return fmt.Sprintf("synced %ds ago", int(elapsed.Seconds()))
-    case elapsed < time.Hour:
-        return fmt.Sprintf("synced %dm ago", int(elapsed.Minutes()))
-    default:
-        return fmt.Sprintf("synced %dh ago", int(elapsed.Hours()))
+    if time.Since(m.lastRefreshed) > staleThreshold {
+        return "Stale"
     }
+    return "Synced"
 }
 ```
 
-New `renderStatusBar()` helper — left/right layout using `lipgloss`:
+`renderStatusBar()` helper — left/right layout with per-state color:
 ```go
 func (m AppModel) renderStatusBar() string {
     leftContent := "j/k navigate • g/G top/bottom • r refresh • q quit"
     rightContent := m.statusRight()
 
-    grayStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#888888"))
-    errStyle  := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF4444"))
+    grayStyle   := lipgloss.NewStyle().Foreground(lipgloss.Color("#888888"))
+    errStyle    := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF4444"))
+    greenStyle  := lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00"))
+    yellowStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFD700"))
 
     var rightStyled string
-    if m.lastErr != "" && !m.refreshing {
+    switch rightContent {
+    case "Synced":
+        rightStyled = greenStyle.Render(rightContent)
+    case "Stale":
+        rightStyled = yellowStyle.Render(rightContent)
+    case "error: " + m.lastErr:
         rightStyled = errStyle.Render(rightContent)
-    } else {
+    default:
         rightStyled = grayStyle.Render(rightContent)
     }
 
@@ -189,9 +196,10 @@ Imports to add: `"time"`
 | `TestCoinsLoadedSetsLastRefreshed` | `coinsLoadedMsg` sets `lastRefreshed` to a non-zero time |
 | `TestPricesUpdatedSetsLastRefreshed` | `pricesUpdatedMsg` sets `lastRefreshed` to a non-zero time |
 | `TestStatusBarShowsLoading` | View with zero coins and no error → status bar right contains `loading...` |
-| `TestStatusBarShowsRefreshing` | View with `refreshing = true` → status bar right contains `refreshing...` |
-| `TestStatusBarShowsError` | View with `lastErr = "some error"` → status bar right contains `error: some error` |
-| `TestStatusBarShowsSyncedAgo` | View after `coinsLoadedMsg` → status bar right contains `synced` and `ago` |
+| `TestStatusBarShowsRefreshing` | `statusRight()` with `refreshing = true` → returns `"Refreshing"` |
+| `TestStatusBarShowsError` | `statusRight()` with `lastErr = "some error"` → returns `"error: some error"` |
+| `TestStatusBarShowsSynced` | `statusRight()` with recent `lastRefreshed` → returns `"Synced"` |
+| `TestStatusBarShowsStale` | `statusRight()` with `lastRefreshed` 6 min ago → returns `"Stale"` |
 | `TestTableRendersWhileError` | View with coins loaded + `lastErr != ""` → view still contains coin names AND error text |
 | `TestInitReturnsBatchedCmd` | `Init()` returns a non-nil cmd (batch of load + tick) |
 | `TestStatusBarHasHintsOnLeft` | View with coins loaded → status bar contains `j/k navigate` |

--- a/docs/issues/004-auto-refresh-status-bar.md
+++ b/docs/issues/004-auto-refresh-status-bar.md
@@ -1,3 +1,227 @@
 ---
-status: pending
+status: in_progress
+branch: feat/004-auto-refresh-status-bar
 ---
+
+## Slice 4 — Auto-refresh + status bar
+
+### Context
+
+Slices 1–3 built the skeleton, full data pipeline, and markets table with 100 scrollable coins. The current `AppModel` already has:
+- `refreshing bool` and `lastErr string` fields
+- `cmdRefresh()` to batch-update prices via `/simple/price`
+- Manual `r` key handler that guards against double-refresh
+- `errMsg` / `pricesUpdatedMsg` message types
+
+What's missing for Slice 4:
+1. **Auto-refresh ticker** — 5 s tick → check if 60 s elapsed → fire `cmdRefresh`
+2. **`lastRefreshed time.Time`** field to track when data was last loaded
+3. **Proper two-sided status bar** replacing the current combined hint line:
+   - Left: keyboard hints (`j/k navigate • g/G top/bottom • r refresh • q quit`)
+   - Right: sync status (`synced Xs ago` / `refreshing...` / `error: <message>` / `loading...`)
+4. **Table always renders** when coins are present, even if `lastErr != ""` — errors go in the status bar only, not as full-screen replacements
+
+---
+
+### Scope
+
+From roadmap bullets:
+- 5 s ticker → checks if 60 s elapsed → fires `cmdRefresh` via `/simple/price`
+- Manual refresh with `r` (no-op if already refreshing) — already implemented, just wired to status bar
+- Status bar: `synced Xs ago` / `refreshing...` / `error: <message>` / `loading...`
+- Error propagation via typed `errMsg`, non-fatal — keeps table usable with stale data
+- **TDD:** tick/refresh state transitions, error display logic
+
+---
+
+### Files to modify
+
+#### `internal/ui/app.go`
+
+**Purpose:** Add ticker, `lastRefreshed`, and replace the simple hint line with a proper two-sided status bar.
+
+**Changes:**
+
+New field on `AppModel`:
+```go
+type AppModel struct {
+    // existing fields unchanged …
+    lastRefreshed time.Time
+}
+```
+
+New message type:
+```go
+// tickMsg fires every 5 s from cmdTick.
+type tickMsg time.Time
+```
+
+New constructor function (package-level, not method — no `AppModel` context needed):
+```go
+func cmdTick() tea.Cmd {
+    return tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
+        return tickMsg(t)
+    })
+}
+```
+
+Updated `Init()` — batch the data-load command with the first tick:
+```go
+func (m AppModel) Init() tea.Cmd {
+    return tea.Batch(m.cmdLoad(), cmdTick())
+}
+```
+
+`cmdLoad()` — extract existing anonymous init function to a named method so `Init()` stays clean:
+```go
+func (m AppModel) cmdLoad() tea.Cmd {
+    return func() tea.Msg { /* existing Init body */ }
+}
+```
+
+Updated `Update()` — add `tickMsg` case and update `lastRefreshed` on success:
+
+```go
+case tickMsg:
+    cmds := []tea.Cmd{cmdTick()} // always re-arm the ticker
+    if !m.refreshing && len(m.coins) > 0 && time.Since(m.lastRefreshed) >= 60*time.Second {
+        m.refreshing = true
+        cmds = append(cmds, m.cmdRefresh())
+    }
+    return m, tea.Batch(cmds...)
+
+case coinsLoadedMsg:
+    m.coins = msg.coins
+    m.lastErr = ""
+    m.lastRefreshed = time.Now()
+    // existing cursor clamping …
+
+case pricesUpdatedMsg:
+    m.coins = msg.coins
+    m.refreshing = false
+    m.lastErr = ""
+    m.lastRefreshed = time.Now()
+```
+
+New `statusRight()` helper (priority: refreshing > error > loading > synced):
+```go
+func (m AppModel) statusRight() string {
+    if m.refreshing {
+        return "refreshing..."
+    }
+    if m.lastErr != "" {
+        return "error: " + m.lastErr
+    }
+    if m.lastRefreshed.IsZero() {
+        return "loading..."
+    }
+    elapsed := time.Since(m.lastRefreshed)
+    switch {
+    case elapsed < time.Minute:
+        return fmt.Sprintf("synced %ds ago", int(elapsed.Seconds()))
+    case elapsed < time.Hour:
+        return fmt.Sprintf("synced %dm ago", int(elapsed.Minutes()))
+    default:
+        return fmt.Sprintf("synced %dh ago", int(elapsed.Hours()))
+    }
+}
+```
+
+New `renderStatusBar()` helper — left/right layout using `lipgloss`:
+```go
+func (m AppModel) renderStatusBar() string {
+    leftContent := "j/k navigate • g/G top/bottom • r refresh • q quit"
+    rightContent := m.statusRight()
+
+    grayStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#888888"))
+    errStyle  := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF4444"))
+
+    var rightStyled string
+    if m.lastErr != "" && !m.refreshing {
+        rightStyled = errStyle.Render(rightContent)
+    } else {
+        rightStyled = grayStyle.Render(rightContent)
+    }
+
+    leftStyled := grayStyle.Render(leftContent)
+    padding := m.width - lipgloss.Width(leftContent) - lipgloss.Width(rightContent)
+    if padding < 1 {
+        padding = 1
+    }
+    return leftStyled + strings.Repeat(" ", padding) + rightStyled
+}
+```
+
+Updated `View()` — remove the early-return error block; always render the table when terminal is big enough; use `renderStatusBar()`:
+```go
+func (m AppModel) View() string {
+    if m.width < 100 || m.height < 30 {
+        return "Terminal too small — resize to at least 100×30"
+    }
+
+    // … existing column/header rendering …
+
+    // When no coins yet, table body is empty rows — status bar shows "loading..."
+    // existing viewport logic unchanged
+
+    // Replace hint line with status bar
+    return strings.Join(lines, "\n") + "\n" + m.renderStatusBar()
+}
+```
+
+Imports to add: `"time"`
+
+---
+
+#### `internal/ui/app_test.go`
+
+**Purpose:** Cover all new tick/refresh state transitions and status bar display logic.
+
+**Test cases to add:**
+
+| Test name | What it verifies |
+|---|---|
+| `TestTickMsgAlwaysReissuesTicker` | On any `tickMsg`, returned `cmd` is non-nil (ticker is re-armed) |
+| `TestTickMsgBelow60sDoesNotRefresh` | `tickMsg` when `lastRefreshed` is 30 s ago → `refreshing` stays false |
+| `TestTickMsgAbove60sFiresRefresh` | `tickMsg` when `lastRefreshed` is 61 s ago → `refreshing = true`, cmd is non-nil |
+| `TestTickMsgWhenAlreadyRefreshing` | `tickMsg` when `refreshing = true` → `refreshing` unchanged, only ticker re-armed |
+| `TestTickMsgWhenNoCoins` | `tickMsg` when `coins` is empty → no refresh even if 60 s elapsed |
+| `TestCoinsLoadedSetsLastRefreshed` | `coinsLoadedMsg` sets `lastRefreshed` to a non-zero time |
+| `TestPricesUpdatedSetsLastRefreshed` | `pricesUpdatedMsg` sets `lastRefreshed` to a non-zero time |
+| `TestStatusBarShowsLoading` | View with zero coins and no error → status bar right contains `loading...` |
+| `TestStatusBarShowsRefreshing` | View with `refreshing = true` → status bar right contains `refreshing...` |
+| `TestStatusBarShowsError` | View with `lastErr = "some error"` → status bar right contains `error: some error` |
+| `TestStatusBarShowsSyncedAgo` | View after `coinsLoadedMsg` → status bar right contains `synced` and `ago` |
+| `TestTableRendersWhileError` | View with coins loaded + `lastErr != ""` → view still contains coin names AND error text |
+| `TestInitReturnsBatchedCmd` | `Init()` returns a non-nil cmd (batch of load + tick) |
+| `TestStatusBarHasHintsOnLeft` | View with coins loaded → status bar contains `j/k navigate` |
+
+**Existing tests to note:**
+- `TestIgnoresOtherKeys` — no change needed; tick is driven by time, not keystrokes.
+- `TestViewRendersHintLine` — checks for `j/k`; still passes because the hint moves to the left side of the status bar.
+
+---
+
+### Implementation order
+
+1. Write failing tests for `tickMsg` state transitions (`TestTickMsgAlwaysReissuesTicker`, `TestTickMsgBelow60sDoesNotRefresh`, `TestTickMsgAbove60sFiresRefresh`, `TestTickMsgWhenAlreadyRefreshing`, `TestTickMsgWhenNoCoins`).
+2. Add `tickMsg` type, `cmdTick()`, `lastRefreshed` field — make tick tests green.
+3. Update `Init()` to call `tea.Batch(m.cmdLoad(), cmdTick())` — update `TestInitReturnsBatchedCmd`.
+4. Update `coinsLoadedMsg` and `pricesUpdatedMsg` handlers to set `lastRefreshed` — make `TestCoinsLoadedSetsLastRefreshed` and `TestPricesUpdatedSetsLastRefreshed` green.
+5. Write failing tests for status bar display.
+6. Implement `statusRight()` and `renderStatusBar()` — make status bar tests green.
+7. Update `View()` to use `renderStatusBar()` and remove the full-screen error block — make `TestTableRendersWhileError` green.
+8. Run `make check` — all tests pass, linter clean.
+
+---
+
+### Verification
+
+```bash
+make check                          # gofumpt + golangci-lint + tests (race) + govulncheck
+go test -race -v ./internal/ui/...  # watch individual test output
+go run ./cmd/crypto-tracker         # manual smoke: status bar shows, auto-refreshes after 60s
+go run ./cmd/crypto-tracker         # kill network, verify "error: ..." in status bar, table stays visible
+```
+
+Expected test output: all existing tests pass + 14 new tests pass.

--- a/docs/reviews/004-auto-refresh-status-bar.md
+++ b/docs/reviews/004-auto-refresh-status-bar.md
@@ -1,0 +1,43 @@
+---
+branch: feat/004-auto-refresh-status-bar
+status: passed
+revision: 1
+---
+
+# Slice 4 — Auto-refresh + status bar
+
+## Smoke test + completeness audit
+
+No findings. All scope items implemented, test coverage adequate, verification
+commands satisfied.
+
+**Scope checklist:**
+- 5 s ticker → checks 60 s threshold → fires `cmdRefresh` ✓ (`tickMsg` case, `cmdTick()`)
+- Manual refresh with `r` (no-op if already refreshing) ✓ (pre-existing, wired to status bar)
+- `staleThreshold = 5 * time.Minute` constant ✓
+- Status bar states: `Synced` (green) / `Stale` (yellow) / `Refreshing` (gray) / `error: <message>` (red) / `loading...` (gray) ✓
+- Error propagation via `errMsg`, non-fatal — table stays visible ✓
+- All 15 required tests present and passing (43 total, race-clean) ✓
+
+**Build and tests:**
+- `make build` — passes cleanly
+- `go test -race ./internal/ui/...` — 43 tests pass, no race conditions
+- `go vet ./...` — no issues
+- Note: `gofumpt` not installed in this environment; `make fmt` step skipped. Code formatting appears clean by inspection.
+
+## Implementation review
+
+No findings. Implementation follows architecture conventions and issue plan.
+
+**Architecture non-negotiables verified:**
+- `ctx context.Context` is the first param of all I/O functions ✓
+- UI layer depends only on `store.Store` interface, never on `*sql.DB` ✓
+- All side effects returned as `tea.Cmd`; no goroutines inside handlers ✓
+- Error wrapping: `fmt.Errorf("outer: %w", err)` throughout ✓
+- `statusRight()` priority order (refreshing > error > loading > stale > synced) matches issue plan ✓
+
+**Notable design choices verified as correct:**
+- `renderStatusBar()` padding uses plain-string widths before styling — correct because ANSI escapes add zero visual width
+- `errMsg` handler does not update `lastRefreshed` — correct; errors do not represent a successful sync
+- `errMsg` clears `m.refreshing = false` — correct; a failed refresh unblocks future retries
+- Empty-coins early return in `View()` still renders the status bar (shows `loading...` or `error: ...` as appropriate)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,7 +36,7 @@ We have to respect the CoinGecko API's rate limiting. So we CAN'T run a request 
 If you find a more efficient solution you're allowed to implement it, but ensure we never hit rate limitings when updating the coins or using the app.
 
 ## Slice 4 — Auto-refresh + status bar
-STATUS: PENDING
+STATUS: IN_PROGRESS
 
 - 5s ticker → checks if 60s elapsed → fires `cmdRefresh` via `/simple/price`
 - Manual refresh with `r` (no-op if already refreshing)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,13 +36,14 @@ We have to respect the CoinGecko API's rate limiting. So we CAN'T run a request 
 If you find a more efficient solution you're allowed to implement it, but ensure we never hit rate limitings when updating the coins or using the app.
 
 ## Slice 4 — Auto-refresh + status bar
-STATUS: IN_REVIEW
+STATUS: DONE
 
 - 5s ticker → checks if 60s elapsed → fires `cmdRefresh` via `/simple/price`
 - Manual refresh with `r` (no-op if already refreshing)
-- Status bar: `synced Xs ago` / `refreshing...` / `error: <message>` / `loading...`
-- Error propagation via typed `errMsg`, non-fatal
-- **TDD:** tick/refresh state transitions, error display logic
+- Status bar states: `Synced` (green) / `Stale` (yellow, > 5 min since last refresh) / `Refreshing` (gray) / `error: <message>` (red) / `loading...` (gray)
+- `staleThreshold = 5 * time.Minute` — data is considered stale after 5 minutes without a successful refresh
+- Error propagation via typed `errMsg`, non-fatal — table stays visible with stale data
+- **TDD:** tick/refresh state transitions, error display logic, stale detection
 
 ## Slice 5 — Tab bar + empty Portfolio tab
 STATUS: PENDING

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,7 +36,7 @@ We have to respect the CoinGecko API's rate limiting. So we CAN'T run a request 
 If you find a more efficient solution you're allowed to implement it, but ensure we never hit rate limitings when updating the coins or using the app.
 
 ## Slice 4 — Auto-refresh + status bar
-STATUS: DONE
+STATUS: IN_REVIEW
 
 - 5s ticker → checks if 60s elapsed → fires `cmdRefresh` via `/simple/price`
 - Manual refresh with `r` (no-op if already refreshing)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,7 +36,7 @@ We have to respect the CoinGecko API's rate limiting. So we CAN'T run a request 
 If you find a more efficient solution you're allowed to implement it, but ensure we never hit rate limitings when updating the coins or using the app.
 
 ## Slice 4 — Auto-refresh + status bar
-STATUS: IN_PROGRESS
+STATUS: DONE
 
 - 5s ticker → checks if 60s elapsed → fires `cmdRefresh` via `/simple/price`
 - Manual refresh with `r` (no-op if already refreshing)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -293,9 +293,9 @@ func (m AppModel) renderStatusBar() string {
 	leftContent := "j/k navigate • g/G top/bottom • r refresh • q quit"
 	rightContent := m.statusRight()
 
-	grayStyle   := lipgloss.NewStyle().Foreground(lipgloss.Color("#888888"))
-	errStyle    := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF4444"))
-	greenStyle  := lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00"))
+	grayStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#888888"))
+	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF4444"))
+	greenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00"))
 	yellowStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFD700"))
 
 	var rightStyled string

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -197,18 +197,8 @@ func (m AppModel) cmdRefresh() tea.Cmd {
 
 // View renders the current state of the app.
 func (m AppModel) View() string {
-	// Check minimum terminal size
 	if m.width < 100 || m.height < 30 {
 		return "Terminal too small — resize to at least 100×30"
-	}
-
-	switch {
-	case m.lastErr != "":
-		return lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#FF0000")).
-			Render("Error: " + m.lastErr)
-	case len(m.coins) == 0:
-		return "loading..."
 	}
 
 	h := m.tableHeight()
@@ -217,7 +207,10 @@ func (m AppModel) View() string {
 		end = len(m.coins)
 	}
 
-	// Column widths
+	if len(m.coins) == 0 {
+		return "loading...\n" + m.renderStatusBar()
+	}
+
 	wRank := 4
 	wName := 22
 	wTicker := 8
@@ -228,7 +221,6 @@ func (m AppModel) View() string {
 	green := lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00"))
 	red := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
 
-	// Header
 	header := fmt.Sprintf(
 		"%*s  %-*s  %-*s  %*s  %*s",
 		wRank, "#",
@@ -268,17 +260,57 @@ func (m AppModel) View() string {
 		lines = append(lines, line)
 	}
 
-	// Pad remaining rows
 	for len(lines)-1 < h {
 		lines = append(lines, "")
 	}
 
-	// Hint line
-	hint := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#888888")).
-		Render("j/k navigate • g/G top/bottom • r refresh • q quit")
+	return strings.Join(lines, "\n") + "\n" + m.renderStatusBar()
+}
 
-	return strings.Join(lines, "\n") + "\n" + hint
+// statusRight returns the right-hand portion of the status bar.
+func (m AppModel) statusRight() string {
+	if m.refreshing {
+		return "refreshing..."
+	}
+	if m.lastErr != "" {
+		return "error: " + m.lastErr
+	}
+	if m.lastRefreshed.IsZero() {
+		return "loading..."
+	}
+	elapsed := time.Since(m.lastRefreshed)
+	switch {
+	case elapsed < time.Minute:
+		return fmt.Sprintf("synced %ds ago", int(elapsed.Seconds()))
+	case elapsed < time.Hour:
+		return fmt.Sprintf("synced %dm ago", int(elapsed.Minutes()))
+	default:
+		return fmt.Sprintf("synced %dh ago", int(elapsed.Hours()))
+	}
+}
+
+// renderStatusBar returns a two-sided status bar with hints on the left and
+// sync status on the right.
+func (m AppModel) renderStatusBar() string {
+	leftContent := "j/k navigate • g/G top/bottom • r refresh • q quit"
+	rightContent := m.statusRight()
+
+	grayStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#888888"))
+	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF4444"))
+
+	var rightStyled string
+	if m.lastErr != "" && !m.refreshing {
+		rightStyled = errStyle.Render(rightContent)
+	} else {
+		rightStyled = grayStyle.Render(rightContent)
+	}
+
+	leftStyled := grayStyle.Render(leftContent)
+	padding := m.width - lipgloss.Width(leftContent) - lipgloss.Width(rightContent)
+	if padding < 1 {
+		padding = 1
+	}
+	return leftStyled + strings.Repeat(" ", padding) + rightStyled
 }
 
 // moveCursor moves the cursor by delta and adjusts the viewport.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -47,6 +47,9 @@ type pricesUpdatedMsg struct {
 // tickMsg fires every 5 seconds from cmdTick.
 type tickMsg time.Time
 
+// staleThreshold is the duration after which data is considered stale.
+const staleThreshold = 5 * time.Minute
+
 // NewAppModel creates a new AppModel with the given dependencies.
 func NewAppModel(ctx context.Context, s store.Store, c api.CoinGeckoClient) AppModel {
 	return AppModel{
@@ -270,7 +273,7 @@ func (m AppModel) View() string {
 // statusRight returns the right-hand portion of the status bar.
 func (m AppModel) statusRight() string {
 	if m.refreshing {
-		return "refreshing..."
+		return "Refreshing"
 	}
 	if m.lastErr != "" {
 		return "error: " + m.lastErr
@@ -278,15 +281,10 @@ func (m AppModel) statusRight() string {
 	if m.lastRefreshed.IsZero() {
 		return "loading..."
 	}
-	elapsed := time.Since(m.lastRefreshed)
-	switch {
-	case elapsed < time.Minute:
-		return fmt.Sprintf("synced %ds ago", int(elapsed.Seconds()))
-	case elapsed < time.Hour:
-		return fmt.Sprintf("synced %dm ago", int(elapsed.Minutes()))
-	default:
-		return fmt.Sprintf("synced %dh ago", int(elapsed.Hours()))
+	if time.Since(m.lastRefreshed) > staleThreshold {
+		return "Stale"
 	}
+	return "Synced"
 }
 
 // renderStatusBar returns a two-sided status bar with hints on the left and
@@ -295,13 +293,20 @@ func (m AppModel) renderStatusBar() string {
 	leftContent := "j/k navigate • g/G top/bottom • r refresh • q quit"
 	rightContent := m.statusRight()
 
-	grayStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#888888"))
-	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF4444"))
+	grayStyle   := lipgloss.NewStyle().Foreground(lipgloss.Color("#888888"))
+	errStyle    := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF4444"))
+	greenStyle  := lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00"))
+	yellowStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFD700"))
 
 	var rightStyled string
-	if m.lastErr != "" && !m.refreshing {
+	switch rightContent {
+	case "Synced":
+		rightStyled = greenStyle.Render(rightContent)
+	case "Stale":
+		rightStyled = yellowStyle.Render(rightContent)
+	case "error: " + m.lastErr:
 		rightStyled = errStyle.Render(rightContent)
-	} else {
+	default:
 		rightStyled = grayStyle.Render(rightContent)
 	}
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -145,6 +145,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case coinsLoadedMsg:
 		m.coins = msg.coins
 		m.lastErr = ""
+		m.lastRefreshed = time.Now()
 		if m.cursor >= len(m.coins) && len(m.coins) > 0 {
 			m.cursor = len(m.coins) - 1
 		}
@@ -155,6 +156,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.coins = msg.coins
 		m.refreshing = false
 		m.lastErr = ""
+		m.lastRefreshed = time.Now()
 	case errMsg:
 		m.lastErr = msg.err.Error()
 		m.refreshing = false

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -15,16 +16,17 @@ import (
 
 // AppModel is the root Bubble Tea model for the crypto-tracker TUI.
 type AppModel struct {
-	width      int
-	height     int
-	ctx        context.Context
-	store      store.Store
-	client     api.CoinGeckoClient
-	coins      []store.Coin
-	lastErr    string
-	refreshing bool
-	cursor     int // index of selected row in m.coins
-	offset     int // index of first visible row (viewport scroll)
+	width         int
+	height        int
+	ctx           context.Context
+	store         store.Store
+	client        api.CoinGeckoClient
+	coins         []store.Coin
+	lastErr       string
+	refreshing    bool
+	lastRefreshed time.Time
+	cursor        int
+	offset        int
 }
 
 // coinsLoadedMsg is sent when coins are successfully loaded from the API.
@@ -42,6 +44,9 @@ type pricesUpdatedMsg struct {
 	coins []store.Coin
 }
 
+// tickMsg fires every 5 seconds from cmdTick.
+type tickMsg time.Time
+
 // NewAppModel creates a new AppModel with the given dependencies.
 func NewAppModel(ctx context.Context, s store.Store, c api.CoinGeckoClient) AppModel {
 	return AppModel{
@@ -49,6 +54,13 @@ func NewAppModel(ctx context.Context, s store.Store, c api.CoinGeckoClient) AppM
 		store:  s,
 		client: c,
 	}
+}
+
+// cmdTick returns a command that fires a tickMsg after 5 seconds.
+func cmdTick() tea.Cmd {
+	return tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
+		return tickMsg(t)
+	})
 }
 
 // Init is the Bubble Tea init command. Fetches initial coin data.
@@ -118,6 +130,13 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+	case tickMsg:
+		cmds := []tea.Cmd{cmdTick()}
+		if !m.refreshing && len(m.coins) > 0 && time.Since(m.lastRefreshed) >= 60*time.Second {
+			m.refreshing = true
+			cmds = append(cmds, m.cmdRefresh())
+		}
+		return m, tea.Batch(cmds...)
 	case coinsLoadedMsg:
 		m.coins = msg.coins
 		m.lastErr = ""

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -65,6 +65,11 @@ func cmdTick() tea.Cmd {
 
 // Init is the Bubble Tea init command. Fetches initial coin data.
 func (m AppModel) Init() tea.Cmd {
+	return tea.Batch(m.cmdLoad(), cmdTick())
+}
+
+// cmdLoad returns a command that loads coins from the database or fetches from API.
+func (m AppModel) cmdLoad() tea.Cmd {
 	return func() tea.Msg {
 		existing, err := m.store.GetAllCoins(m.ctx)
 		if err != nil {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -756,8 +756,8 @@ func TestStatusBarShowsRefreshing(t *testing.T) {
 	m.lastRefreshed = time.Now()
 
 	right := m.statusRight()
-	if right != "refreshing..." {
-		t.Errorf("expected statusRight 'refreshing...', got %q", right)
+	if right != "Refreshing" {
+		t.Errorf("expected statusRight 'Refreshing', got %q", right)
 	}
 }
 
@@ -777,18 +777,33 @@ func TestStatusBarShowsError(t *testing.T) {
 	}
 }
 
-func TestStatusBarShowsSyncedAgo(t *testing.T) {
+func TestStatusBarShowsSynced(t *testing.T) {
 	stub := &StubStore{}
 	api := &StubAPI{}
 	m := NewAppModel(context.Background(), stub, api)
 	m.width = 100
 	m.height = 30
 	m.coins = threeCoins()
-	m.lastRefreshed = time.Now().Add(-25 * time.Second)
+	m.lastRefreshed = time.Now()
 
 	right := m.statusRight()
-	if !strings.Contains(right, "synced") || !strings.Contains(right, "ago") {
-		t.Errorf("expected statusRight to contain 'synced' and 'ago', got %q", right)
+	if right != "Synced" {
+		t.Errorf("expected statusRight 'Synced', got %q", right)
+	}
+}
+
+func TestStatusBarShowsStale(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.width = 100
+	m.height = 30
+	m.coins = threeCoins()
+	m.lastRefreshed = time.Now().Add(-6 * time.Minute)
+
+	right := m.statusRight()
+	if right != "Stale" {
+		t.Errorf("expected statusRight 'Stale', got %q", right)
 	}
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -731,3 +731,97 @@ func TestPricesUpdatedSetsLastRefreshed(t *testing.T) {
 		t.Error("expected refreshing to be false after pricesUpdatedMsg")
 	}
 }
+
+func TestStatusBarShowsLoading(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.width = 100
+	m.height = 30
+
+	right := m.statusRight()
+	if right != "loading..." {
+		t.Errorf("expected statusRight 'loading...', got %q", right)
+	}
+}
+
+func TestStatusBarShowsRefreshing(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.width = 100
+	m.height = 30
+	m.coins = threeCoins()
+	m.refreshing = true
+	m.lastRefreshed = time.Now()
+
+	right := m.statusRight()
+	if right != "refreshing..." {
+		t.Errorf("expected statusRight 'refreshing...', got %q", right)
+	}
+}
+
+func TestStatusBarShowsError(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.width = 100
+	m.height = 30
+	m.coins = threeCoins()
+	m.lastErr = "some error"
+	m.lastRefreshed = time.Now()
+
+	right := m.statusRight()
+	if right != "error: some error" {
+		t.Errorf("expected statusRight 'error: some error', got %q", right)
+	}
+}
+
+func TestStatusBarShowsSyncedAgo(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.width = 100
+	m.height = 30
+	m.coins = threeCoins()
+	m.lastRefreshed = time.Now().Add(-25 * time.Second)
+
+	right := m.statusRight()
+	if !strings.Contains(right, "synced") || !strings.Contains(right, "ago") {
+		t.Errorf("expected statusRight to contain 'synced' and 'ago', got %q", right)
+	}
+}
+
+func TestTableRendersWhileError(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.width = 100
+	m.height = 30
+	m.coins = threeCoins()
+	m.lastRefreshed = time.Now()
+	m.lastErr = "network failed"
+
+	view := m.View()
+	if !strings.Contains(view, "Coin 1") {
+		t.Error("expected view to contain coin names even with error")
+	}
+	if !strings.Contains(view, "error: network failed") {
+		t.Error("expected view to contain error text")
+	}
+}
+
+func TestStatusBarHasHintsOnLeft(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.width = 100
+	m.height = 30
+	m.coins = threeCoins()
+	m.lastRefreshed = time.Now()
+
+	view := m.View()
+	if !strings.Contains(view, "j/k navigate") {
+		t.Errorf("expected view to contain 'j/k navigate', got %q", view)
+	}
+}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/fredericomozzato/crypto_tracker/internal/store"
@@ -590,5 +591,86 @@ func TestCursorClampedAfterCoinsLoaded(t *testing.T) {
 	model := updated.(AppModel)
 	if model.cursor != 2 {
 		t.Errorf("expected cursor clamped to 2 (last index), got %d", model.cursor)
+	}
+}
+
+func TestTickMsgAlwaysReissuesTicker(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+
+	updated, cmd := m.Update(tickMsg(time.Now()))
+	model := updated.(AppModel)
+
+	if cmd == nil {
+		t.Error("expected non-nil cmd from tickMsg (ticker should be re-armed)")
+	}
+	_ = model
+}
+
+func TestTickMsgBelow60sDoesNotRefresh(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.coins = threeCoins()
+	m.lastRefreshed = time.Now().Add(-30 * time.Second)
+
+	updated, _ := m.Update(tickMsg(time.Now()))
+	model := updated.(AppModel)
+
+	if model.refreshing {
+		t.Error("expected refreshing to stay false when 60s not elapsed")
+	}
+}
+
+func TestTickMsgAbove60sFiresRefresh(t *testing.T) {
+	stub := &StubStore{coins: threeCoins()}
+	api := &StubAPI{prices: map[string]float64{"coin-1": 100.0}}
+	m := NewAppModel(context.Background(), stub, api)
+	m.coins = threeCoins()
+	m.lastRefreshed = time.Now().Add(-61 * time.Second)
+	m.refreshing = false
+
+	updated, cmd := m.Update(tickMsg(time.Now()))
+	model := updated.(AppModel)
+
+	if !model.refreshing {
+		t.Error("expected refreshing to be true when 60+ seconds elapsed")
+	}
+	if cmd == nil {
+		t.Error("expected non-nil cmd when refresh fires")
+	}
+}
+
+func TestTickMsgWhenAlreadyRefreshing(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.coins = threeCoins()
+	m.lastRefreshed = time.Now().Add(-61 * time.Second)
+	m.refreshing = true
+
+	updated, cmd := m.Update(tickMsg(time.Now()))
+	model := updated.(AppModel)
+
+	if !model.refreshing {
+		t.Error("expected refreshing to remain true")
+	}
+	if cmd == nil {
+		t.Error("expected non-nil cmd (ticker re-arm) even when already refreshing")
+	}
+}
+
+func TestTickMsgWhenNoCoins(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.lastRefreshed = time.Now().Add(-61 * time.Second)
+
+	updated, _ := m.Update(tickMsg(time.Now()))
+	model := updated.(AppModel)
+
+	if model.refreshing {
+		t.Error("expected no refresh when no coins loaded")
 	}
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -692,3 +692,42 @@ func TestTickMsgWhenNoCoins(t *testing.T) {
 		t.Error("expected no refresh when no coins loaded")
 	}
 }
+
+func TestCoinsLoadedSetsLastRefreshed(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.width = 100
+	m.height = 30
+
+	if !m.lastRefreshed.IsZero() {
+		t.Error("expected lastRefreshed to be zero initially")
+	}
+
+	updated, _ := m.Update(coinsLoadedMsg{coins: threeCoins()})
+	model := updated.(AppModel)
+
+	if model.lastRefreshed.IsZero() {
+		t.Error("expected lastRefreshed to be set after coinsLoadedMsg")
+	}
+}
+
+func TestPricesUpdatedSetsLastRefreshed(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.width = 100
+	m.height = 30
+	m.coins = threeCoins()
+	m.refreshing = true
+
+	updated, _ := m.Update(pricesUpdatedMsg{coins: threeCoins()})
+	model := updated.(AppModel)
+
+	if model.lastRefreshed.IsZero() {
+		t.Error("expected lastRefreshed to be set after pricesUpdatedMsg")
+	}
+	if model.refreshing {
+		t.Error("expected refreshing to be false after pricesUpdatedMsg")
+	}
+}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -150,7 +150,7 @@ func TestIgnoresOtherKeys(t *testing.T) {
 	}
 }
 
-func TestInitReturnsCmd(t *testing.T) {
+func TestInitReturnsBatchedCmd(t *testing.T) {
 	stub := &StubStore{}
 	api := &StubAPI{}
 	m := NewAppModel(context.Background(), stub, api)
@@ -398,8 +398,7 @@ func TestInitFetchesHundredCoinsOnFirstLaunch(t *testing.T) {
 	s := &StubStore{}
 	m := NewAppModel(context.Background(), s, api)
 
-	cmd := m.Init()
-	msg := cmd()
+	msg := executeInitBatch(t, m)
 
 	loaded, ok := msg.(coinsLoadedMsg)
 	if !ok {
@@ -419,8 +418,7 @@ func TestInitLoadsFromDBOnSubsequentLaunch(t *testing.T) {
 	s := &StubStore{coins: coins}
 	m := NewAppModel(context.Background(), s, api)
 
-	cmd := m.Init()
-	msg := cmd()
+	msg := executeInitBatch(t, m)
 
 	loaded, ok := msg.(coinsLoadedMsg)
 	if !ok {
@@ -441,8 +439,7 @@ func TestInitRefetchesWhenDBPartiallySeeded(t *testing.T) {
 	s := &StubStore{coins: partial}
 	m := NewAppModel(context.Background(), s, api)
 
-	cmd := m.Init()
-	msg := cmd()
+	msg := executeInitBatch(t, m)
 
 	loaded, ok := msg.(coinsLoadedMsg)
 	if !ok {
@@ -454,6 +451,27 @@ func TestInitRefetchesWhenDBPartiallySeeded(t *testing.T) {
 	if len(api.fetchMarketsCalls) != 1 || api.fetchMarketsCalls[0] != 100 {
 		t.Errorf("expected FetchMarkets called with 100, got %v", api.fetchMarketsCalls)
 	}
+}
+
+// executeInitBatch runs the batched command from Init() and returns the first
+// coinsLoadedMsg or errMsg found.
+func executeInitBatch(t *testing.T, m AppModel) tea.Msg {
+	t.Helper()
+	cmd := m.Init()
+	result := cmd()
+	batch, ok := result.(tea.BatchMsg)
+	if !ok {
+		return result
+	}
+	for _, c := range batch {
+		msg := c()
+		switch msg.(type) {
+		case coinsLoadedMsg, errMsg:
+			return msg
+		}
+	}
+	t.Fatal("no coinsLoadedMsg or errMsg in batch")
+	return nil
 }
 
 func threeCoins() []store.Coin {


### PR DESCRIPTION
## Summary

- Adds auto-refresh: prices update automatically every 60 s via \`/simple/price\` (no user action needed)
- Replaces the plain hint line with a two-sided status bar: keyboard hints on the left, sync state on the right
- Right-side states: `Synced` (green) / `Stale` (yellow, after 5 min without a successful refresh) / `Refreshing` (gray) / `error: <message>` (red) / `loading...` (gray) — replacing the previous `synced Xs ago` time counter
- Errors are non-fatal: the table stays visible with stale data; errors surface in the status bar only

## Test Plan

- [ ] `go test -race ./...` — 72 tests pass, no race conditions
- [ ] `make build` — binary compiles cleanly
- [ ] `go run ./cmd/crypto-tracker` — status bar visible at bottom; transitions to `Synced` after load
- [ ] Leave running 60 s → status briefly shows `Refreshing`, returns to `Synced`
- [ ] Leave idle 5+ min → status transitions to `Stale` (yellow)
- [ ] Kill network → `r` shows `error: ...` in status bar; table remains usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)