### PR TITLE
feat(slice-009): portfolio edit and delete

### DIFF
--- a/docs/issues/009-portfolio-edit-delete.md
+++ b/docs/issues/009-portfolio-edit-delete.md
@@ -1,0 +1,415 @@
+---
+status: done
+branch: feat/009-portfolio-edit-delete
+---
+
+# Slice 9 — Portfolio Management (Edit and Delete)
+
+## Context
+
+Slices 1–8 are complete. The portfolio tab supports browsing, creating, adding/editing/deleting holdings, and two-panel layout with focus highlighting. The `PortfolioModel` uses a discriminated union `portfolioMode` with 7 states: `browsing`, `creating`, `addCoin`, `addAmount`, `listing`, `editingAmount`, `deleting`. Slice 9 adds the ability to **rename** and **delete** portfolios from the left panel, plus a `UNIQUE` constraint on portfolio names.
+
+Since we are in development mode, no production data migration is needed — we can delete the existing DB and let the schema re-create from scratch.
+
+## Scope
+
+From roadmap:
+- `e` in browsing mode → open edit dialog for selected portfolio (pre-populated with current name)
+- `Esc` cancels edit → returns to browsing
+- `Enter` saves: empty/whitespace-only = no-op return to browsing; same name = no-op return to browsing; duplicate name = inline error message; unique name = save and return to browsing
+- `X` in browsing mode → delete confirmation dialog showing portfolio name
+- `Enter` confirms delete → portfolio is deleted, returns to browsing
+- `Esc` cancels delete → returns to browsing
+- After delete: portfolios reload, cursor repositioned (clamped), holdings reload for new selection (or empty state if no portfolios remain)
+- TDD: name uniqueness, edit/delete state transitions
+
+## Data Model
+
+### Schema change — `internal/db/schema.sql`
+
+Add `UNIQUE` constraint to `portfolios.name`:
+
+```sql
+CREATE TABLE IF NOT EXISTS portfolios (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT    NOT NULL UNIQUE,
+    created_at INTEGER NOT NULL DEFAULT 0
+);
+```
+
+No migration code needed in `db.go`. Since we are in development, delete the existing DB file and let `CREATE TABLE IF NOT EXISTS` rebuild it with the new constraint.
+
+### Store interface additions — `internal/store/store.go`
+
+```go
+RenamePortfolio(ctx context.Context, id int64, name string) error
+DeletePortfolio(ctx context.Context, id int64) error
+```
+
+### `RenamePortfolio` — `internal/store/sqlite.go`
+
+```go
+func (s *SQLiteStore) RenamePortfolio(ctx context.Context, id int64, name string) error {
+    result, err := s.db.ExecContext(ctx,
+        `UPDATE portfolios SET name = ? WHERE id = ?`, name, id,
+    )
+    if err != nil {
+        return fmt.Errorf("renaming portfolio: %w", err)
+    }
+    rows, err := result.RowsAffected()
+    if err != nil {
+        return fmt.Errorf("renaming portfolio %d: %w", id, err)
+    }
+    if rows == 0 {
+        return fmt.Errorf("renaming portfolio %d: not found", id)
+    }
+    return nil
+}
+```
+
+The `UNIQUE` constraint on `name` will cause a duplicate-name error from SQLite. The UI pre-validates to give a friendly inline error message; the DB constraint is the safety net.
+
+### `DeletePortfolio` — `internal/store/sqlite.go`
+
+```go
+func (s *SQLiteStore) DeletePortfolio(ctx context.Context, id int64) error {
+    _, err := s.db.ExecContext(ctx, `DELETE FROM portfolios WHERE id = ?`, id)
+    if err != nil {
+        return fmt.Errorf("deleting portfolio %d: %w", id, err)
+    }
+    return nil
+}
+```
+
+Cascade (`ON DELETE CASCADE` on `holdings.portfolio_id`) automatically deletes all holdings for the portfolio.
+
+## New mode types — `internal/ui/portfolio.go`
+
+```go
+type editingPortfolio struct {
+    portfolio store.Portfolio
+    input     textinput.Model
+    errMsg    string
+}
+
+type deletingPortfolio struct {
+    portfolio store.Portfolio
+}
+
+func (editingPortfolio) isPortfolioMode()  {}
+func (deletingPortfolio) isPortfolioMode()   {}
+```
+
+## New message type — `internal/ui/portfolio.go`
+
+```go
+type portfolioDeletedMsg struct {
+    portfolios []store.Portfolio
+}
+```
+
+## Key handler changes — `internal/ui/portfolio.go`
+
+### `browsing` mode additions
+
+```go
+case 'e', 'E':
+    if len(m.portfolios) > 0 {
+        m = m.openEditPortfolioDialog()
+        return m, nil
+    }
+case 'X', 'x':
+    if len(m.portfolios) > 0 {
+        m.mode = deletingPortfolio{portfolio: m.portfolios[m.cursor]}
+        return m, nil
+    }
+```
+
+### `editingPortfolio` mode handler
+
+```go
+case editingPortfolio:
+    switch msg.Type {
+    case tea.KeyEsc:
+        m.mode = browsing{}
+        return m, nil
+    case tea.KeyEnter:
+        name := strings.TrimSpace(mode.input.Value())
+        if name == "" || name == mode.portfolio.Name {
+            m.mode = browsing{}
+            return m, nil
+        }
+        for _, p := range m.portfolios {
+            if p.Name == name && p.ID != mode.portfolio.ID {
+                mode.errMsg = "name already exists"
+                m.mode = mode
+                return m, nil
+            }
+        }
+        return m, m.cmdRenamePortfolio(mode.portfolio.ID, name)
+    default:
+        newInput, cmd := mode.input.Update(msg)
+        mode.input = newInput
+        m.mode = mode
+        return m, cmd
+    }
+```
+
+### `deletingPortfolio` mode handler
+
+```go
+case deletingPortfolio:
+    switch msg.Type {
+    case tea.KeyEsc:
+        m.mode = browsing{}
+        return m, nil
+    case tea.KeyEnter:
+        return m, m.cmdDeletePortfolio(mode.portfolio.ID)
+    }
+    // All other keys ignored
+```
+
+### New message handler — `portfolioDeletedMsg`
+
+```go
+case portfolioDeletedMsg:
+    m.portfolios = msg.portfolios
+    m.mode = browsing{}
+    m.scrollOffset = 0
+    m.holdingsCursor = 0
+    if len(m.portfolios) == 0 {
+        m.cursor = 0
+        m.holdings = nil
+        m.lastErr = ""
+        return m, nil
+    }
+    if m.cursor >= len(m.portfolios) {
+        m.cursor = len(m.portfolios) - 1
+    }
+    if m.cursor < 0 {
+        m.cursor = 0
+    }
+    m.lastErr = ""
+    return m, m.cmdLoadHoldings(m.portfolios[m.cursor].ID)
+```
+
+The `portfoliosLoadedMsg` handler is reused for rename (with `focusID` set to the renamed portfolio's ID).
+
+### New command functions
+
+```go
+func (m PortfolioModel) cmdRenamePortfolio(portfolioID int64, name string) tea.Cmd {
+    return func() tea.Msg {
+        if err := m.store.RenamePortfolio(m.ctx, portfolioID, name); err != nil {
+            return errMsg{err: fmt.Errorf("renaming portfolio: %w", err)}
+        }
+        portfolios, err := m.store.GetAllPortfolios(m.ctx)
+        if err != nil {
+            return errMsg{err: fmt.Errorf("loading portfolios after rename: %w", err)}
+        }
+        return portfoliosLoadedMsg{portfolios: portfolios, focusID: portfolioID}
+    }
+}
+
+func (m PortfolioModel) cmdDeletePortfolio(portfolioID int64) tea.Cmd {
+    return func() tea.Msg {
+        if err := m.store.DeletePortfolio(m.ctx, portfolioID); err != nil {
+            return errMsg{err: fmt.Errorf("deleting portfolio: %w", err)}
+        }
+        portfolios, err := m.store.GetAllPortfolios(m.ctx)
+        if err != nil {
+            return errMsg{err: fmt.Errorf("loading portfolios after delete: %w", err)}
+        }
+        return portfolioDeletedMsg{portfolios: portfolios}
+    }
+}
+```
+
+### `openEditPortfolioDialog` helper
+
+```go
+func (m PortfolioModel) openEditPortfolioDialog() PortfolioModel {
+    ti := textinput.New()
+    ti.Placeholder = "e.g. Long Term"
+    ti.CharLimit = 50
+    ti.Focus()
+    ti.SetValue(m.portfolios[m.cursor].Name)
+    m.mode = editingPortfolio{
+        portfolio: m.portfolios[m.cursor],
+        input:     ti,
+    }
+    return m
+}
+```
+
+### `InputActive()` update
+
+```go
+case creating, addCoin, addAmount, editingAmount, editingPortfolio:
+    return true
+```
+
+### `View()` update — new dialog rendering
+
+```go
+case editingPortfolio:
+    dialog := m.renderEditPortfolioDialog(mode)
+    content := lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, dialog)
+    return content + "\n" + m.renderStatusBar()
+
+case deletingPortfolio:
+    dialog := m.renderDeletePortfolioDialog(mode)
+    content := lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, dialog)
+    return content + "\n" + m.renderStatusBar()
+```
+
+### Dialog renderers
+
+```go
+func (m PortfolioModel) renderEditPortfolioDialog(mode editingPortfolio) string {
+    var b strings.Builder
+    b.WriteString("Rename Portfolio\n\n")
+    b.WriteString(mode.input.View() + "\n")
+    if mode.errMsg != "" {
+        b.WriteString("\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000")).Render(mode.errMsg))
+    }
+    return lipgloss.NewStyle().
+        Border(lipgloss.RoundedBorder()).
+        Padding(1, 2).
+        Render(b.String())
+}
+
+func (m PortfolioModel) renderDeletePortfolioDialog(mode deletingPortfolio) string {
+    var b strings.Builder
+    b.WriteString("Delete Portfolio\n\n")
+    b.WriteString(mode.portfolio.Name + "\n\n")
+    b.WriteString("Press Enter to confirm, or Esc to cancel.")
+    return lipgloss.NewStyle().
+        Border(lipgloss.RoundedBorder()).
+        Padding(1, 2).
+        Render(b.String())
+}
+```
+
+### Status bar update
+
+```go
+case browsing:
+    content = "j/k portfolios • Enter list • e edit • X delete • PgUp/PgDn scroll • a add • n new • q quit"
+case editingPortfolio:
+    content = "Enter to save • Esc to cancel"
+case deletingPortfolio:
+    content = "Enter to delete • Esc to cancel"
+```
+
+### Border highlighting
+
+Both `editingPortfolio` and `deletingPortfolio` are launched from browsing mode (left panel focus). In the `View()` focus determination, both should show the left panel as focused:
+
+```go
+case browsing, creating, addCoin, addAmount, editingPortfolio, deletingPortfolio:
+    leftFocused = true
+```
+
+## Tests
+
+### `internal/store/sqlite_test.go`
+
+- **`TestRenamePortfolio`** — rename a portfolio, verify name updated via `GetAllPortfolios`
+- **`TestRenamePortfolioDuplicateName`** — create two portfolios, try to rename one to the other's name, expect error
+- **`TestRenamePortfolioNotFound`** — rename a nonexistent ID, expect error
+- **`TestDeletePortfolio`** — create a portfolio, delete it, verify it's gone
+- **`TestDeletePortfolioCascadeHoldings`** — create portfolio + coin + holding, delete portfolio, verify holding was cascade-deleted
+- **`TestDeletePortfolioNotFound`** — delete nonexistent ID, no error (idempotent)
+- **`TestCreatePortfolioDuplicateName`** — verify that creating two portfolios with the same name fails (UNIQUE constraint)
+
+### `internal/ui/portfolio_test.go`
+
+- **`TestBrowsingEKeyOpensEditDialog`** — press `e` in browsing mode with portfolios → transitions to `editingPortfolio`
+- **`TestBrowsingEKeyNoPortfoliosIsNoOp`** — press `e` with no portfolios → no-op
+- **`TestEditingPortfolioEscReturnsToBrowsing`** — Esc from edit dialog returns to browsing
+- **`TestEditingPortfolioEnterWithEmptyNameReturnsToBrowsing`** — empty name after trim → return to browsing
+- **`TestEditingPortfolioEnterWithSameNameReturnsToBrowsing`** — unchanged name → return to browsing
+- **`TestEditingPortfolioEnterWithDuplicateNameShowsError`** — type name of another portfolio, Enter, `errMsg` is set
+- **`TestEditingPortfolioEnterWithValidNameReturnsCmd`** — type a valid new name, Enter, cmd is non-nil
+- **`TestEditingPortfolioInputActive`** — `editingPortfolio` mode → `InputActive()` returns true
+- **`TestEditingPortfolioPrePopulatedName`** — the text input contains the current portfolio name
+- **`TestBrowsingXKeyOpensDeleteDialog`** — press `X` in browsing mode → transitions to `deletingPortfolio`
+- **`TestBrowsingXKeyNoPortfoliosIsNoOp`** — press `X` with no portfolios → no-op
+- **`TestDeletingPortfolioEscReturnsToBrowsing`** — Esc from delete dialog returns to browsing
+- **`TestDeletingPortfolioEnterReturnsCmd`** — Enter in delete dialog returns non-nil command
+- **`TestDeletingPortfolioOtherKeysIgnored`** — other keys (j, k, a, n, 1) are silently ignored
+- **`TestDeletingPortfolioInputActive`** — `deletingPortfolio` mode → `InputActive()` returns false
+- **`TestPortfolioDeletedMsgUpdatesPortfolios`** — `portfolioDeletedMsg` replaces `m.portfolios`
+- **`TestPortfolioDeletedMsgClampsCursor`** — if cursor >= len after delete, it's clamped
+- **`TestPortfolioDeletedMsgResetsScrollOffset`** — scroll offset is reset to 0 after delete
+- **`TestPortfolioDeletedMsgToBrowsingWhenEmpty`** — if all portfolios deleted, mode is browsing with empty holdings
+- **`TestPortfolioDeletedMsgLoadsHoldingsForNewSelection`** — after delete with remaining portfolios, cmd loads holdings
+- **`TestEditPortfolioDialogShowsCurrentName`** — `View()` in `editingPortfolio` mode contains the portfolio name
+- **`TestDeletePortfolioDialogShowsName`** — `View()` in `deletingPortfolio` mode contains the portfolio name
+
+### `internal/ui/testhelpers_test.go`
+
+Add stub methods to `StubStore`:
+
+```go
+func (s *StubStore) RenamePortfolio(ctx context.Context, id int64, name string) error {
+    if s.err != nil {
+        return s.err
+    }
+    for i, p := range s.portfolios {
+        if p.ID == id {
+            s.portfolios[i].Name = name
+            return nil
+        }
+    }
+    return nil
+}
+
+func (s *StubStore) DeletePortfolio(ctx context.Context, id int64) error {
+    for i, p := range s.portfolios {
+        if p.ID == id {
+            s.portfolios = append(s.portfolios[:i], s.portfolios[i+1:]...)
+            return nil
+        }
+    }
+    return nil
+}
+```
+
+### `internal/db/db_test.go`
+
+Add test for the UNIQUE constraint:
+
+- **`TestUniquePortfolioName`** — verify that creating two portfolios with the same name fails
+
+## Implementation Order
+
+1. Update `schema.sql` — add `UNIQUE` to `portfolios.name`
+2. Add `RenamePortfolio` and `DeletePortfolio` to `Store` interface in `store.go`
+3. Implement `RenamePortfolio` and `DeletePortfolio` in `sqlite.go`
+4. Write store tests in `sqlite_test.go` (TDD: write tests first, then verify implementation passes)
+5. Add `editingPortfolio` and `deletingPortfolio` mode types, `portfolioDeletedMsg`, and `isPortfolioMode()` implementations to `portfolio.go`
+6. Add `RenamePortfolio` and `DeletePortfolio` stub methods to `testhelpers_test.go`
+7. Write UI tests for state transitions in `portfolio_test.go` (TDD: all tests red at this point)
+8. Implement `browsing` mode key handlers (`e`, `X`)
+9. Implement `editingPortfolio` and `deletingPortfolio` update handlers
+10. Implement `portfolioDeletedMsg` handler
+11. Implement `cmdRenamePortfolio` and `cmdDeletePortfolio`
+12. Implement `openEditPortfolioDialog` helper
+13. Update `InputActive()`, `View()`, `renderStatusBar()`
+14. Write view tests (`TestEditPortfolioDialogShowsCurrentName`, `TestDeletePortfolioDialogShowsName`)
+15. Delete existing development DB file and run `make check` — all tests pass, lint clean, no race conditions
+
+## Verification
+
+```bash
+make check
+go test -race -run TestRename -v ./internal/store/
+go test -race -run TestDeletePortfolio -v ./internal/store/
+go test -race -run TestEditingPortfolio -v ./internal/ui/
+go test -race -run TestDeletingPortfolio -v ./internal/ui/
+go test -race -run TestBrowsingE -v ./internal/ui/
+go test -race -run TestBrowsingX -v ./internal/ui/
+go test -race -run TestPortfolioDeleted -v ./internal/ui/
+```

--- a/docs/reviews/009-portfolio-edit-delete/revision-1.md
+++ b/docs/reviews/009-portfolio-edit-delete/revision-1.md
@@ -1,0 +1,75 @@
+---
+branch: feat/009-portfolio-edit-delete
+revision: 1
+status: done
+---
+
+# Slice 9 — Portfolio Management: Edit and Delete (Revision 1)
+
+## Smoke test + completeness audit
+
+All 220 tests pass. Binary compiles cleanly (`go build ./...`). No panics.
+
+**Completeness gaps:**
+
+| ID | Sev | Status | Summary |
+|----|-----|--------|---------|
+| C1 | LOW | FIXED | `TestUniquePortfolioName` missing from `internal/db/db_test.go` |
+
+**C1** `internal/db/db_test.go`
+The issue plan specifies adding `TestUniquePortfolioName` to `internal/db/db_test.go` to verify the schema-level UNIQUE constraint. The file still contains only the stub `TestPackageCompiles`. Equivalent coverage exists at the store layer (`TestCreatePortfolioDuplicateName` in `sqlite_test.go`), so this is not a coverage gap — it is an unexecuted plan step. Worth adding for completeness at the DB layer.
+
+---
+
+## Implementation review + user-reported findings
+
+The following findings come from both code review and manual testing by the developer.
+
+| ID | Sev | Status | Summary |
+|----|-----|--------|---------|
+| F1 | HIGH | FIXED | Duplicate name error on create shows raw wrapped Go error, unstyled |
+| F2 | HIGH | FIXED | Edit/create dialogs grow as text is typed — no fixed width |
+| F3 | HIGH | FIXED | `a` (add holding) accessible from browsing mode — should be list-mode only |
+| F4 | MED  | FIXED | Enter on empty portfolio is a no-op — should enter holdings panel |
+
+---
+
+**F1** `internal/ui/portfolio.go:928–940` — `cmdCreatePortfolio`
+
+When `CreatePortfolio` hits the UNIQUE constraint, SQLite returns an error. `cmdCreatePortfolio` wraps it and sends an `errMsg`. The `errMsg` handler sets `m.lastErr = msg.err.Error()`, which results in a string like `creating portfolio "Foo": UNIQUE constraint failed: portfolios.name`. This is displayed in `renderStatusBar` as plain text with no colour change, appended to the full key-hint line — easy to miss.
+
+The fix is two-part:
+1. Intercept the UNIQUE constraint error in `cmdCreatePortfolio` (check `strings.Contains(err.Error(), "UNIQUE")`) and return a friendly `errMsg{err: errors.New("portfolio \"Foo\" already exists")}`.
+2. Make `renderStatusBar` render the error segment in red (consistent with how the inline dialog errors are styled): use `lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000")).Render("error: " + m.lastErr)` for the error suffix.
+
+Note: the `editingPortfolio` mode pre-validates duplicates client-side and shows a red inline message in the dialog — that path already works well. This finding is specific to the `creating` path, where validation goes through the DB layer.
+
+---
+
+**F2** `internal/ui/portfolio.go:1196–1207` — `renderEditPortfolioDialog`; also `internal/ui/portfolio.go:606–611` — `creating` dialog in `View()`
+
+Neither the edit-portfolio dialog nor the create-portfolio dialog applies a fixed `Width()` to its outer `lipgloss.NewStyle()`. Lipgloss sizes the box to fit its content, so the dialog grows horizontally as the user types, which looks broken.
+
+Both dialogs should use a proportional fixed width (e.g. `m.width / 2` clamped to a minimum). The `textinput` should also be width-constrained so the text doesn't overflow the box. The `CharLimit = 50` prevents unbounded input but does not constrain rendering width.
+
+Fix: add `.Width(dialogWidth)` to the outer `lipgloss.NewStyle()` in both `renderEditPortfolioDialog` and the inline `creating` dialog, and set `ti.Width = dialogWidth - 6` (accounting for padding and border) in `openEditPortfolioDialog` and `openCreateDialog`.
+
+---
+
+**F3** `internal/ui/portfolio.go:161–164` — `browsing` mode `'a'` handler; `internal/ui/portfolio.go:857` — status bar
+
+The `browsing` mode currently handles `a`/`A` to open the coin picker (add holding). The user reports this is confusing: `n` creates a new portfolio, `a` adds a holding, and both work from the same mode. The UX expectation is that holding management belongs inside the holdings panel (list mode), not from the portfolio navigation level.
+
+Remove the `'a'`, `'A'` case from the `browsing` mode key handler. Remove `• a add` from the `browsing` status bar hint. The `a` shortcut should remain in `listing` mode (already implemented).
+
+Also remove `a add` from the `browsing` status bar string at line 857.
+
+---
+
+**F4** `internal/ui/portfolio.go:192–199` — `browsing` mode `tea.KeyEnter` handler
+
+When a portfolio is selected but has no holdings, pressing Enter is a no-op. The user expects Enter to enter the right panel (holdings area) regardless of whether holdings exist. Currently the code gates on `len(m.holdings) > 0`.
+
+The fix: always transition to `listing{}` on Enter when a portfolio exists, even if holdings are empty. The `listing` mode already handles an empty holdings list gracefully (shows "no holdings — press a to add one"). The `holdingsCursor` clamping handles the empty case. Remove the `len(m.holdings) > 0` guard.
+
+Note: the PRD specifies "Only available when the selected portfolio has at least one holding", but the developer's UX feedback supersedes the PRD here — the panel should always be enterable so users can immediately add holdings after creating a portfolio.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -81,7 +81,21 @@ STATUS: DONE
 - `PgUp`/`PgDn` -> preview scrolling from menu mode
 - **TDD:** edit/delete state machine, cursor clamping after deletion
 
-## Slice 9 — Terminal size guard + `--debug` logging
+## Slice 9 - Portfolio management (edit and delete)
+STATUS: DONE
+
+When in the portfolios panel:
+
+- `e` to edit a portfolio's name
+- Open the edit dialogue box and allow user to edit the name. Renders the current name in the box
+- `esc` returns to portfolios panel, `enter` saves new name and returns to portfolios panel
+- Ensure portfolios' names are unique with error message and no-op editing if the name is repeated
+- `X` on a portfolio opens the deletion confirmation box
+- `enter` deletes the portfolio and returns to the portfolios panel
+- `esc` cancels the deletion and returns to the portfolios panel
+- **TDD**: ensures uniqueness, confirm the deletion and editing work
+
+## Slice 10 — Terminal size guard + `--debug` logging
 STATUS: PENDING
 
 - Minimum 100×30 enforced — centered message if too small, re-renders on resize

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,7 +1,35 @@
 package db
 
-import "testing"
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
 
 func TestPackageCompiles(t *testing.T) {
 	t.Log("db package compiles")
+}
+
+func TestUniquePortfolioName(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	// Insert first portfolio
+	_, err = database.ExecContext(ctx, "INSERT INTO portfolios (name, created_at) VALUES (?, ?)", "Test Portfolio", 1234567890)
+	if err != nil {
+		t.Fatalf("failed to insert first portfolio: %v", err)
+	}
+
+	// Try to insert second portfolio with same name - should fail due to UNIQUE constraint
+	_, err = database.ExecContext(ctx, "INSERT INTO portfolios (name, created_at) VALUES (?, ?)", "Test Portfolio", 1234567891)
+	if err == nil {
+		t.Error("expected error when inserting portfolio with duplicate name, got nil")
+	}
 }

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS coins (
 
 CREATE TABLE IF NOT EXISTS portfolios (
     id         INTEGER PRIMARY KEY AUTOINCREMENT,
-    name       TEXT    NOT NULL,
+    name       TEXT    NOT NULL UNIQUE,
     created_at INTEGER NOT NULL DEFAULT 0
 );
 

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -179,6 +179,34 @@ func (s *SQLiteStore) DeleteHolding(ctx context.Context, id int64) error {
 	return nil
 }
 
+// RenamePortfolio updates the name of a portfolio.
+func (s *SQLiteStore) RenamePortfolio(ctx context.Context, id int64, name string) error {
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE portfolios SET name = ? WHERE id = ?`, name, id,
+	)
+	if err != nil {
+		return fmt.Errorf("renaming portfolio: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("renaming portfolio %d: %w", id, err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("renaming portfolio %d: not found", id)
+	}
+	return nil
+}
+
+// DeletePortfolio deletes a portfolio by its ID.
+// Holdings are cascade-deleted via ON DELETE CASCADE on holdings.portfolio_id.
+func (s *SQLiteStore) DeletePortfolio(ctx context.Context, id int64) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM portfolios WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("deleting portfolio %d: %w", id, err)
+	}
+	return nil
+}
+
 // GetHoldingsForPortfolio returns all holdings for a portfolio joined with coin data.
 func (s *SQLiteStore) GetHoldingsForPortfolio(ctx context.Context, portfolioID int64) ([]HoldingRow, error) {
 	rows, err := s.db.QueryContext(ctx, `

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1051,3 +1051,255 @@ func TestDeleteHoldingNonExistentIsNoOp(t *testing.T) {
 		t.Errorf("expected no error deleting non-existent holding, got: %v", err)
 	}
 }
+
+func TestRenamePortfolio(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	s := NewSQLiteStore(database)
+	defer func() {
+		_ = s.Close()
+	}()
+
+	// Create a portfolio
+	p, err := s.CreatePortfolio(ctx, "Old Name")
+	if err != nil {
+		t.Fatalf("failed to create portfolio: %v", err)
+	}
+
+	// Rename it
+	if err := s.RenamePortfolio(ctx, p.ID, "New Name"); err != nil {
+		t.Fatalf("failed to rename portfolio: %v", err)
+	}
+
+	// Verify the rename
+	portfolios, err := s.GetAllPortfolios(ctx)
+	if err != nil {
+		t.Fatalf("failed to get portfolios: %v", err)
+	}
+
+	if len(portfolios) != 1 {
+		t.Fatalf("expected 1 portfolio, got %d", len(portfolios))
+	}
+
+	if portfolios[0].Name != "New Name" {
+		t.Errorf("expected name 'New Name', got %s", portfolios[0].Name)
+	}
+}
+
+func TestRenamePortfolioDuplicateName(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	s := NewSQLiteStore(database)
+	defer func() {
+		_ = s.Close()
+	}()
+
+	// Create two portfolios
+	p1, err := s.CreatePortfolio(ctx, "Portfolio A")
+	if err != nil {
+		t.Fatalf("failed to create first portfolio: %v", err)
+	}
+
+	_, err = s.CreatePortfolio(ctx, "Portfolio B")
+	if err != nil {
+		t.Fatalf("failed to create second portfolio: %v", err)
+	}
+
+	// Try to rename p1 to "Portfolio B" - should fail due to UNIQUE constraint
+	if err := s.RenamePortfolio(ctx, p1.ID, "Portfolio B"); err == nil {
+		t.Error("expected error when renaming to duplicate name, got nil")
+	}
+}
+
+func TestRenamePortfolioNotFound(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	s := NewSQLiteStore(database)
+	defer func() {
+		_ = s.Close()
+	}()
+
+	// Try to rename non-existent portfolio
+	if err := s.RenamePortfolio(ctx, 99999, "New Name"); err == nil {
+		t.Error("expected error when renaming non-existent portfolio, got nil")
+	}
+}
+
+func TestDeletePortfolio(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	s := NewSQLiteStore(database)
+	defer func() {
+		_ = s.Close()
+	}()
+
+	// Create a portfolio
+	p, err := s.CreatePortfolio(ctx, "To Delete")
+	if err != nil {
+		t.Fatalf("failed to create portfolio: %v", err)
+	}
+
+	// Delete it
+	if err := s.DeletePortfolio(ctx, p.ID); err != nil {
+		t.Fatalf("failed to delete portfolio: %v", err)
+	}
+
+	// Verify it's gone
+	portfolios, err := s.GetAllPortfolios(ctx)
+	if err != nil {
+		t.Fatalf("failed to get portfolios: %v", err)
+	}
+
+	if len(portfolios) != 0 {
+		t.Errorf("expected 0 portfolios after delete, got %d", len(portfolios))
+	}
+}
+
+func TestDeletePortfolioCascadeHoldings(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	s := NewSQLiteStore(database)
+	defer func() {
+		_ = s.Close()
+	}()
+
+	// Create a coin
+	coin := Coin{
+		ApiID:  "bitcoin",
+		Name:   "Bitcoin",
+		Ticker: "BTC",
+		Rate:   67000.00,
+	}
+	if err := s.UpsertCoin(ctx, coin); err != nil {
+		t.Fatalf("failed to upsert coin: %v", err)
+	}
+
+	coins, err := s.GetAllCoins(ctx)
+	if err != nil {
+		t.Fatalf("failed to get coins: %v", err)
+	}
+	coinID := coins[0].ID
+
+	// Create a portfolio
+	p, err := s.CreatePortfolio(ctx, "Test Portfolio")
+	if err != nil {
+		t.Fatalf("failed to create portfolio: %v", err)
+	}
+
+	// Add a holding
+	if err := s.UpsertHolding(ctx, p.ID, coinID, 1.5); err != nil {
+		t.Fatalf("failed to upsert holding: %v", err)
+	}
+
+	// Verify holding exists
+	holdings, err := s.GetHoldingsForPortfolio(ctx, p.ID)
+	if err != nil {
+		t.Fatalf("failed to get holdings: %v", err)
+	}
+	if len(holdings) != 1 {
+		t.Fatalf("expected 1 holding, got %d", len(holdings))
+	}
+
+	// Delete the portfolio
+	if err := s.DeletePortfolio(ctx, p.ID); err != nil {
+		t.Fatalf("failed to delete portfolio: %v", err)
+	}
+
+	// Verify holdings are cascade-deleted
+	holdings, err = s.GetHoldingsForPortfolio(ctx, p.ID)
+	if err != nil {
+		t.Fatalf("failed to get holdings after delete: %v", err)
+	}
+	if len(holdings) != 0 {
+		t.Errorf("expected 0 holdings after portfolio delete, got %d", len(holdings))
+	}
+}
+
+func TestDeletePortfolioNotFound(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	s := NewSQLiteStore(database)
+	defer func() {
+		_ = s.Close()
+	}()
+
+	// Delete non-existent portfolio - should not error (idempotent)
+	if err := s.DeletePortfolio(ctx, 99999); err != nil {
+		t.Errorf("expected no error deleting non-existent portfolio, got: %v", err)
+	}
+}
+
+func TestCreatePortfolioDuplicateName(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	s := NewSQLiteStore(database)
+	defer func() {
+		_ = s.Close()
+	}()
+
+	// Create first portfolio
+	if _, err := s.CreatePortfolio(ctx, "Duplicate Name"); err != nil {
+		t.Fatalf("failed to create first portfolio: %v", err)
+	}
+
+	// Try to create second with same name - should fail due to UNIQUE constraint
+	if _, err := s.CreatePortfolio(ctx, "Duplicate Name"); err == nil {
+		t.Error("expected error when creating portfolio with duplicate name, got nil")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -59,4 +59,8 @@ type Store interface {
 	UpsertHolding(ctx context.Context, portfolioID, coinID int64, amount float64) error
 	DeleteHolding(ctx context.Context, id int64) error
 	GetHoldingsForPortfolio(ctx context.Context, portfolioID int64) ([]HoldingRow, error)
+
+	// new in Slice 9
+	RenamePortfolio(ctx context.Context, id int64, name string) error
+	DeletePortfolio(ctx context.Context, id int64) error
 }

--- a/internal/ui/portfolio.go
+++ b/internal/ui/portfolio.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -44,15 +45,25 @@ type (
 		holding  store.HoldingRow
 		listMode listing // preserved so Esc/cancel returns to list mode with state intact
 	}
+	editingPortfolio struct {
+		portfolio store.Portfolio
+		input     textinput.Model
+		errMsg    string
+	}
+	deletingPortfolio struct {
+		portfolio store.Portfolio
+	}
 )
 
-func (browsing) isPortfolioMode()      {}
-func (creating) isPortfolioMode()      {}
-func (addCoin) isPortfolioMode()       {}
-func (addAmount) isPortfolioMode()     {}
-func (listing) isPortfolioMode()       {}
-func (editingAmount) isPortfolioMode() {}
-func (deleting) isPortfolioMode()      {}
+func (browsing) isPortfolioMode()          {}
+func (creating) isPortfolioMode()          {}
+func (addCoin) isPortfolioMode()           {}
+func (addAmount) isPortfolioMode()         {}
+func (listing) isPortfolioMode()           {}
+func (editingAmount) isPortfolioMode()     {}
+func (deleting) isPortfolioMode()          {}
+func (editingPortfolio) isPortfolioMode()  {}
+func (deletingPortfolio) isPortfolioMode() {}
 
 // portfoliosLoadedMsg is sent when portfolios are loaded from the store.
 // focusID is non-zero when the cursor should be positioned on a specific portfolio.
@@ -80,6 +91,11 @@ type holdingsSavedMsg struct {
 // holdingDeletedMsg is sent after a holding is successfully deleted.
 type holdingDeletedMsg struct {
 	holdings []store.HoldingRow
+}
+
+// portfolioDeletedMsg is sent after a portfolio is successfully deleted.
+type portfolioDeletedMsg struct {
+	portfolios []store.Portfolio
 }
 
 // PortfolioModel is the Portfolio tab with two-panel layout.
@@ -142,9 +158,15 @@ func (m PortfolioModel) update(msg tea.Msg) (PortfolioModel, tea.Cmd) {
 						return m, nil
 					case 'n', 'N':
 						return m.openCreateDialog(), nil
-					case 'a', 'A':
+					case 'e', 'E':
 						if len(m.portfolios) > 0 {
-							return m, m.cmdOpenCoinPicker()
+							return m.openEditPortfolioDialog(), nil
+						}
+						return m, nil
+					case 'X', 'x':
+						if len(m.portfolios) > 0 {
+							m.mode = deletingPortfolio{portfolio: m.portfolios[m.cursor]}
+							return m, nil
 						}
 						return m, nil
 					}
@@ -164,8 +186,8 @@ func (m PortfolioModel) update(msg tea.Msg) (PortfolioModel, tea.Cmd) {
 				}
 				return m, nil
 			case tea.KeyEnter:
-				// Enter list mode if we have holdings
-				if len(m.holdings) > 0 {
+				// Enter list mode if we have a portfolio (even if no holdings)
+				if len(m.portfolios) > 0 {
 					m.mode = listing{}
 					m.holdingsCursor = 0
 					m.scrollOffset = 0
@@ -392,6 +414,42 @@ func (m PortfolioModel) update(msg tea.Msg) (PortfolioModel, tea.Cmd) {
 				return m, nil
 			}
 			// All other keys ignored in deleting mode
+
+		case editingPortfolio:
+			switch msg.Type {
+			case tea.KeyEsc:
+				m.mode = browsing{}
+				return m, nil
+			case tea.KeyEnter:
+				name := strings.TrimSpace(mode.input.Value())
+				if name == "" || name == mode.portfolio.Name {
+					m.mode = browsing{}
+					return m, nil
+				}
+				for _, p := range m.portfolios {
+					if p.Name == name && p.ID != mode.portfolio.ID {
+						mode.errMsg = "name already exists"
+						m.mode = mode
+						return m, nil
+					}
+				}
+				return m, m.cmdRenamePortfolio(mode.portfolio.ID, name)
+			default:
+				newInput, cmd := mode.input.Update(msg)
+				mode.input = newInput
+				m.mode = mode
+				return m, cmd
+			}
+
+		case deletingPortfolio:
+			switch msg.Type {
+			case tea.KeyEsc:
+				m.mode = browsing{}
+				return m, nil
+			case tea.KeyEnter:
+				return m, m.cmdDeletePortfolio(mode.portfolio.ID)
+			}
+			// All other keys ignored
 		}
 
 	case portfoliosLoadedMsg:
@@ -496,6 +554,26 @@ func (m PortfolioModel) update(msg tea.Msg) (PortfolioModel, tea.Cmd) {
 		}
 		return m, nil
 
+	case portfolioDeletedMsg:
+		m.portfolios = msg.portfolios
+		m.mode = browsing{}
+		m.scrollOffset = 0
+		m.holdingsCursor = 0
+		if len(m.portfolios) == 0 {
+			m.cursor = 0
+			m.holdings = nil
+			m.lastErr = ""
+			return m, nil
+		}
+		if m.cursor >= len(m.portfolios) {
+			m.cursor = len(m.portfolios) - 1
+		}
+		if m.cursor < 0 {
+			m.cursor = 0
+		}
+		m.lastErr = ""
+		return m, m.cmdLoadHoldings(m.portfolios[m.cursor].ID)
+
 	case errMsg:
 		m.lastErr = msg.err.Error()
 		return m, nil
@@ -507,7 +585,7 @@ func (m PortfolioModel) update(msg tea.Msg) (PortfolioModel, tea.Cmd) {
 // InputActive returns true when a text input is focused.
 func (m PortfolioModel) InputActive() bool {
 	switch m.mode.(type) {
-	case creating, addCoin, addAmount, editingAmount:
+	case creating, addCoin, addAmount, editingAmount, editingPortfolio:
 		return true
 	}
 	return false
@@ -522,9 +600,13 @@ func (m PortfolioModel) View() string {
 	// Dialog modes: creating, addCoin, addAmount
 	switch mode := m.mode.(type) {
 	case creating:
+		dialogWidth := intMin(intMax(m.width/2, 40), 60)
+		inputWidth := dialogWidth - 6 // Account for padding and border
+		mode.input.Width = inputWidth
 		dialog := lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			Padding(1, 2).
+			Width(dialogWidth).
 			Render("New Portfolio\n\n" + mode.input.View())
 		content := lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, dialog)
 		return content + "\n" + m.renderStatusBar()
@@ -548,6 +630,16 @@ func (m PortfolioModel) View() string {
 		dialog := m.renderDeleteDialog(mode)
 		content := lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, dialog)
 		return content + "\n" + m.renderStatusBar()
+
+	case editingPortfolio:
+		dialog := m.renderEditPortfolioDialog(mode)
+		content := lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, dialog)
+		return content + "\n" + m.renderStatusBar()
+
+	case deletingPortfolio:
+		dialog := m.renderDeletePortfolioDialog(mode)
+		content := lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, dialog)
+		return content + "\n" + m.renderStatusBar()
 	}
 
 	contentHeight := m.height - 3 // Reserve 1 row for status bar, 2 for borders
@@ -568,7 +660,7 @@ func (m PortfolioModel) View() string {
 	leftFocused := false
 	rightFocused := false
 	switch m.mode.(type) {
-	case browsing, creating, addCoin, addAmount:
+	case browsing, creating, addCoin, addAmount, editingPortfolio, deletingPortfolio:
 		leftFocused = true
 	case listing, editingAmount, deleting:
 		// When in dialog modes from list mode, right panel stays focused
@@ -762,7 +854,7 @@ func (m PortfolioModel) renderStatusBar() string {
 	var content string
 	switch m.mode.(type) {
 	case browsing:
-		content = "j/k portfolios • Enter list • PgUp/PgDn scroll • a add • n new • q quit"
+		content = "j/k portfolios • Enter list • e edit • X delete • PgUp/PgDn scroll • n new • q quit"
 	case creating:
 		content = "Enter to create • Esc to cancel"
 	case addCoin:
@@ -775,13 +867,34 @@ func (m PortfolioModel) renderStatusBar() string {
 		content = "Enter to save • Esc cancel"
 	case deleting:
 		content = "Enter to confirm delete • Esc cancel"
+	case editingPortfolio:
+		content = "Enter to save • Esc to cancel"
+	case deletingPortfolio:
+		content = "Enter to delete • Esc to cancel"
 	}
 
 	if m.lastErr != "" {
-		content += " • error: " + m.lastErr
+		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
+		content += " • " + errStyle.Render("error: "+m.lastErr)
 	}
 
 	return content
+}
+
+func (m PortfolioModel) openEditPortfolioDialog() PortfolioModel {
+	ti := textinput.New()
+	ti.Placeholder = "e.g. Long Term"
+	ti.CharLimit = 50
+	ti.Focus()
+	ti.SetValue(m.portfolios[m.cursor].Name)
+	// Set width based on dialog width calculation (will be set properly in View)
+	dialogWidth := intMin(intMax(m.width/2, 40), 60)
+	ti.Width = dialogWidth - 6 // Account for padding and border
+	m.mode = editingPortfolio{
+		portfolio: m.portfolios[m.cursor],
+		input:     ti,
+	}
+	return m
 }
 
 func (m *PortfolioModel) moveCursor(delta int) {
@@ -820,6 +933,9 @@ func (m PortfolioModel) cmdCreatePortfolio(name string) tea.Cmd {
 	return func() tea.Msg {
 		p, err := m.store.CreatePortfolio(m.ctx, name)
 		if err != nil {
+			if strings.Contains(err.Error(), "UNIQUE") {
+				return errMsg{err: errors.New("portfolio \"" + name + "\" already exists")}
+			}
 			return errMsg{err: fmt.Errorf("creating portfolio: %w", err)}
 		}
 		portfolios, err := m.store.GetAllPortfolios(m.ctx)
@@ -827,17 +943,6 @@ func (m PortfolioModel) cmdCreatePortfolio(name string) tea.Cmd {
 			return errMsg{err: fmt.Errorf("loading portfolios after create: %w", err)}
 		}
 		return portfoliosLoadedMsg{portfolios: portfolios, focusID: p.ID}
-	}
-}
-
-// cmdOpenCoinPicker loads all coins from the store.
-func (m PortfolioModel) cmdOpenCoinPicker() tea.Cmd {
-	return func() tea.Msg {
-		coins, err := m.store.GetAllCoins(m.ctx)
-		if err != nil {
-			return errMsg{err: fmt.Errorf("loading coins for picker: %w", err)}
-		}
-		return coinPickerReadyMsg{coins: coins, origin: browsing{}}
 	}
 }
 
@@ -1024,6 +1129,34 @@ func (m PortfolioModel) cmdDeleteHolding(portfolioID, holdingID int64, listMode 
 	}
 }
 
+// cmdRenamePortfolio renames a portfolio and reloads portfolios.
+func (m PortfolioModel) cmdRenamePortfolio(portfolioID int64, name string) tea.Cmd {
+	return func() tea.Msg {
+		if err := m.store.RenamePortfolio(m.ctx, portfolioID, name); err != nil {
+			return errMsg{err: fmt.Errorf("renaming portfolio: %w", err)}
+		}
+		portfolios, err := m.store.GetAllPortfolios(m.ctx)
+		if err != nil {
+			return errMsg{err: fmt.Errorf("loading portfolios after rename: %w", err)}
+		}
+		return portfoliosLoadedMsg{portfolios: portfolios, focusID: portfolioID}
+	}
+}
+
+// cmdDeletePortfolio deletes a portfolio and reloads portfolios.
+func (m PortfolioModel) cmdDeletePortfolio(portfolioID int64) tea.Cmd {
+	return func() tea.Msg {
+		if err := m.store.DeletePortfolio(m.ctx, portfolioID); err != nil {
+			return errMsg{err: fmt.Errorf("deleting portfolio: %w", err)}
+		}
+		portfolios, err := m.store.GetAllPortfolios(m.ctx)
+		if err != nil {
+			return errMsg{err: fmt.Errorf("loading portfolios after delete: %w", err)}
+		}
+		return portfolioDeletedMsg{portfolios: portfolios}
+	}
+}
+
 // renderEditAmountDialog renders the edit amount dialog.
 func (m PortfolioModel) renderEditAmountDialog(mode editingAmount) string {
 	var b strings.Builder
@@ -1049,6 +1182,34 @@ func (m PortfolioModel) renderDeleteDialog(mode deleting) string {
 	_, _ = fmt.Fprintf(&b, "Value: %s\n\n", format.FmtMoney(mode.holding.Value))
 	b.WriteString("Press Enter to confirm deletion, or Esc to cancel.")
 
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		Padding(1, 2).
+		Render(b.String())
+}
+
+// renderEditPortfolioDialog renders the edit portfolio dialog.
+func (m PortfolioModel) renderEditPortfolioDialog(mode editingPortfolio) string {
+	var b strings.Builder
+	b.WriteString("Rename Portfolio\n\n")
+	b.WriteString(mode.input.View() + "\n")
+	if mode.errMsg != "" {
+		b.WriteString("\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000")).Render(mode.errMsg))
+	}
+	dialogWidth := intMin(intMax(m.width/2, 40), 60)
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		Padding(1, 2).
+		Width(dialogWidth).
+		Render(b.String())
+}
+
+// renderDeletePortfolioDialog renders the delete portfolio confirmation dialog.
+func (m PortfolioModel) renderDeletePortfolioDialog(mode deletingPortfolio) string {
+	var b strings.Builder
+	b.WriteString("Delete Portfolio\n\n")
+	b.WriteString(mode.portfolio.Name + "\n\n")
+	b.WriteString("Press Enter to confirm, or Esc to cancel.")
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		Padding(1, 2).

--- a/internal/ui/portfolio_test.go
+++ b/internal/ui/portfolio_test.go
@@ -283,27 +283,30 @@ func TestPortfolioHandlesWindowSizeMsg(t *testing.T) {
 	}
 }
 
-func TestPortfolioAKeyWhenNoPortfoliosIsNoOp(t *testing.T) {
+func TestPortfolioAKeyInBrowsingModeIsNoOp(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{})
 	m.width = 100
 	m.height = 30
 	_, cmd := m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
 	if cmd != nil {
-		t.Error("expected nil cmd when pressing 'a' with no portfolios")
+		t.Error("expected nil cmd when pressing 'a' in browsing mode")
 	}
 }
 
-func TestPortfolioAKeyOpensCoinPicker(t *testing.T) {
+func TestPortfolioAKeyInListModeOpensCoinPicker(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
-		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
+		portfolios:  []store.Portfolio{{ID: 1, Name: "Test"}},
+		holdingRows: []store.HoldingRow{{ID: 1, CoinID: 1, Name: "Bitcoin", Ticker: "BTC"}},
 	})
 	m.width = 100
 	m.height = 30
-	// Load portfolios into model
+	// Load portfolios and holdings into model, then enter list mode
 	m, _ = m.update(portfoliosLoadedMsg{portfolios: []store.Portfolio{{ID: 1, Name: "Test"}}})
+	m, _ = m.update(holdingsLoadedMsg{holdings: []store.HoldingRow{{ID: 1, CoinID: 1, Name: "Bitcoin", Ticker: "BTC"}}})
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyEnter}) // Enter list mode
 	_, cmd := m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
 	if cmd == nil {
-		t.Error("expected non-nil cmd when pressing 'a' with portfolios")
+		t.Error("expected non-nil cmd when pressing 'a' in list mode")
 	}
 }
 
@@ -706,7 +709,7 @@ func TestEnterFromBrowsingToListingMode(t *testing.T) {
 	}
 }
 
-func TestEnterFromBrowsingNoHoldingsIsNoOp(t *testing.T) {
+func TestEnterFromBrowsingNoHoldingsEntersListMode(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{})
 	m.width = 100
 	m.height = 30
@@ -715,9 +718,9 @@ func TestEnterFromBrowsingNoHoldingsIsNoOp(t *testing.T) {
 
 	updated, _ := m.update(tea.KeyMsg{Type: tea.KeyEnter})
 
-	// Should still be in browsing mode
-	if _, ok := updated.mode.(browsing); !ok {
-		t.Errorf("expected browsing mode, got %T", updated.mode)
+	// Should enter list mode even with no holdings
+	if _, ok := updated.mode.(listing); !ok {
+		t.Errorf("expected listing mode, got %T", updated.mode)
 	}
 }
 
@@ -1387,6 +1390,390 @@ func TestPortfolioInputActiveForAddAmountMode(t *testing.T) {
 	m.mode = addAmount{}
 	if !m.InputActive() {
 		t.Error("expected InputActive() to be true for addAmount mode")
+	}
+}
+
+// Slice 9 tests - Portfolio Edit and Delete
+
+func TestBrowsingEKeyOpensEditDialog(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.width = 100
+	m.height = 30
+	m.portfolios = []store.Portfolio{
+		{ID: 1, Name: "Test Portfolio"},
+	}
+
+	updated, _ := m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+
+	if _, ok := updated.mode.(editingPortfolio); !ok {
+		t.Errorf("expected editingPortfolio mode, got %T", updated.mode)
+	}
+}
+
+func TestBrowsingEKeyNoPortfoliosIsNoOp(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.width = 100
+	m.height = 30
+	m.portfolios = []store.Portfolio{}
+
+	updated, _ := m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+
+	if _, ok := updated.mode.(browsing); !ok {
+		t.Errorf("expected browsing mode when no portfolios, got %T", updated.mode)
+	}
+}
+
+func TestEditingPortfolioEscReturnsToBrowsing(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.width = 100
+	m.height = 30
+	m.mode = editingPortfolio{
+		portfolio: store.Portfolio{ID: 1, Name: "Test"},
+		input:     textinput.New(),
+	}
+
+	updated, _ := m.update(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if _, ok := updated.mode.(browsing); !ok {
+		t.Errorf("expected browsing mode after Esc, got %T", updated.mode)
+	}
+}
+
+func TestEditingPortfolioEnterWithEmptyNameReturnsToBrowsing(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.width = 100
+	m.height = 30
+	ti := textinput.New()
+	m.mode = editingPortfolio{
+		portfolio: store.Portfolio{ID: 1, Name: "Test"},
+		input:     ti,
+	}
+
+	updated, _ := m.update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if _, ok := updated.mode.(browsing); !ok {
+		t.Errorf("expected browsing mode after Enter with empty name, got %T", updated.mode)
+	}
+}
+
+func TestEditingPortfolioEnterWithSameNameReturnsToBrowsing(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.width = 100
+	m.height = 30
+	ti := textinput.New()
+	ti.SetValue("Test")
+	m.mode = editingPortfolio{
+		portfolio: store.Portfolio{ID: 1, Name: "Test"},
+		input:     ti,
+	}
+
+	updated, _ := m.update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if _, ok := updated.mode.(browsing); !ok {
+		t.Errorf("expected browsing mode after Enter with same name, got %T", updated.mode)
+	}
+}
+
+func TestEditingPortfolioEnterWithDuplicateNameShowsError(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.width = 100
+	m.height = 30
+	m.portfolios = []store.Portfolio{
+		{ID: 1, Name: "Portfolio A"},
+		{ID: 2, Name: "Portfolio B"},
+	}
+	ti := textinput.New()
+	ti.SetValue("Portfolio B") // Try to rename Portfolio A to Portfolio B
+	m.mode = editingPortfolio{
+		portfolio: store.Portfolio{ID: 1, Name: "Portfolio A"},
+		input:     ti,
+	}
+
+	updated, _ := m.update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if mode, ok := updated.mode.(editingPortfolio); ok {
+		if mode.errMsg == "" {
+			t.Error("expected error message for duplicate name")
+		}
+	} else {
+		t.Errorf("expected to stay in editingPortfolio mode, got %T", updated.mode)
+	}
+}
+
+func TestEditingPortfolioEnterWithValidNameReturnsCmd(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{
+		portfolios: []store.Portfolio{
+			{ID: 1, Name: "Old Name"},
+		},
+	})
+	m.width = 100
+	m.height = 30
+	m.portfolios = []store.Portfolio{
+		{ID: 1, Name: "Old Name"},
+	}
+	ti := textinput.New()
+	ti.Focus()
+	ti.SetValue("New Name")
+	m.mode = editingPortfolio{
+		portfolio: store.Portfolio{ID: 1, Name: "Old Name"},
+		input:     ti,
+	}
+
+	_, cmd := m.update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if cmd == nil {
+		t.Error("expected non-nil cmd with valid name")
+	}
+}
+
+func TestEditingPortfolioInputActive(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.mode = editingPortfolio{}
+
+	if !m.InputActive() {
+		t.Error("expected InputActive() to be true for editingPortfolio mode")
+	}
+}
+
+func TestEditingPortfolioPrePopulatedName(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.width = 100
+	m.height = 30
+	m.portfolios = []store.Portfolio{
+		{ID: 1, Name: "Current Name"},
+	}
+
+	updated, _ := m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+
+	if mode, ok := updated.mode.(editingPortfolio); ok {
+		if mode.input.Value() != "Current Name" {
+			t.Errorf("expected input to be pre-populated with 'Current Name', got %q", mode.input.Value())
+		}
+	} else {
+		t.Errorf("expected editingPortfolio mode, got %T", updated.mode)
+	}
+}
+
+func TestBrowsingXKeyOpensDeleteDialog(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.width = 100
+	m.height = 30
+	m.portfolios = []store.Portfolio{
+		{ID: 1, Name: "Test Portfolio"},
+	}
+
+	updated, _ := m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'X'}})
+
+	if _, ok := updated.mode.(deletingPortfolio); !ok {
+		t.Errorf("expected deletingPortfolio mode, got %T", updated.mode)
+	}
+}
+
+func TestBrowsingXKeyNoPortfoliosIsNoOp(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.width = 100
+	m.height = 30
+	m.portfolios = []store.Portfolio{}
+
+	updated, _ := m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'X'}})
+
+	if _, ok := updated.mode.(browsing); !ok {
+		t.Errorf("expected browsing mode when no portfolios, got %T", updated.mode)
+	}
+}
+
+func TestDeletingPortfolioEscReturnsToBrowsing(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.width = 100
+	m.height = 30
+	m.mode = deletingPortfolio{
+		portfolio: store.Portfolio{ID: 1, Name: "Test"},
+	}
+
+	updated, _ := m.update(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if _, ok := updated.mode.(browsing); !ok {
+		t.Errorf("expected browsing mode after Esc, got %T", updated.mode)
+	}
+}
+
+func TestDeletingPortfolioEnterReturnsCmd(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{
+		portfolios: []store.Portfolio{
+			{ID: 1, Name: "Test"},
+		},
+	})
+	m.width = 100
+	m.height = 30
+	m.portfolios = []store.Portfolio{
+		{ID: 1, Name: "Test"},
+	}
+	m.mode = deletingPortfolio{
+		portfolio: store.Portfolio{ID: 1, Name: "Test"},
+	}
+
+	_, cmd := m.update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if cmd == nil {
+		t.Error("expected non-nil cmd when confirming delete")
+	}
+}
+
+func TestDeletingPortfolioOtherKeysIgnored(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.width = 100
+	m.height = 30
+	m.mode = deletingPortfolio{
+		portfolio: store.Portfolio{ID: 1, Name: "Test"},
+	}
+
+	// Press various keys
+	for _, key := range []rune{'j', 'k', 'a', 'n', '1'} {
+		updated, _ := m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{key}})
+		if _, ok := updated.mode.(deletingPortfolio); !ok {
+			t.Errorf("expected to stay in deletingPortfolio mode after pressing %c, got %T", key, updated.mode)
+		}
+	}
+}
+
+func TestDeletingPortfolioInputActive(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.mode = deletingPortfolio{}
+
+	if m.InputActive() {
+		t.Error("expected InputActive() to be false for deletingPortfolio mode")
+	}
+}
+
+func TestPortfolioDeletedMsgUpdatesPortfolios(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.portfolios = []store.Portfolio{
+		{ID: 1, Name: "Portfolio A"},
+		{ID: 2, Name: "Portfolio B"},
+	}
+
+	updatedPortfolios := []store.Portfolio{
+		{ID: 1, Name: "Portfolio A"},
+	}
+
+	updated, _ := m.update(portfolioDeletedMsg{portfolios: updatedPortfolios})
+
+	if len(updated.portfolios) != 1 {
+		t.Errorf("expected 1 portfolio after delete, got %d", len(updated.portfolios))
+	}
+}
+
+func TestPortfolioDeletedMsgClampsCursor(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.portfolios = []store.Portfolio{
+		{ID: 1, Name: "Portfolio A"},
+		{ID: 2, Name: "Portfolio B"},
+		{ID: 3, Name: "Portfolio C"},
+	}
+	m.cursor = 2 // on last portfolio
+
+	// Delete the last two portfolios
+	updatedPortfolios := []store.Portfolio{
+		{ID: 1, Name: "Portfolio A"},
+	}
+
+	updated, _ := m.update(portfolioDeletedMsg{portfolios: updatedPortfolios})
+
+	if updated.cursor != 0 {
+		t.Errorf("expected cursor clamped to 0, got %d", updated.cursor)
+	}
+}
+
+func TestPortfolioDeletedMsgResetsScrollOffset(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.portfolios = []store.Portfolio{
+		{ID: 1, Name: "Portfolio A"},
+	}
+	m.scrollOffset = 10
+
+	updated, _ := m.update(portfolioDeletedMsg{portfolios: []store.Portfolio{}})
+
+	if updated.scrollOffset != 0 {
+		t.Errorf("expected scrollOffset reset to 0, got %d", updated.scrollOffset)
+	}
+}
+
+func TestPortfolioDeletedMsgToBrowsingWhenEmpty(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.portfolios = []store.Portfolio{
+		{ID: 1, Name: "Portfolio A"},
+	}
+	m.mode = deletingPortfolio{}
+
+	updated, _ := m.update(portfolioDeletedMsg{portfolios: []store.Portfolio{}})
+
+	if _, ok := updated.mode.(browsing); !ok {
+		t.Errorf("expected browsing mode when all portfolios deleted, got %T", updated.mode)
+	}
+
+	if updated.holdings != nil {
+		t.Error("expected holdings to be nil when no portfolios")
+	}
+}
+
+func TestPortfolioDeletedMsgLoadsHoldingsForNewSelection(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{
+		portfolios: []store.Portfolio{
+			{ID: 1, Name: "Remaining"},
+		},
+	})
+	m.portfolios = []store.Portfolio{
+		{ID: 1, Name: "To Delete"},
+		{ID: 2, Name: "Remaining"},
+	}
+	m.cursor = 0
+	m.mode = deletingPortfolio{}
+
+	updatedPortfolios := []store.Portfolio{
+		{ID: 2, Name: "Remaining"},
+	}
+
+	_, cmd := m.update(portfolioDeletedMsg{portfolios: updatedPortfolios})
+
+	if cmd == nil {
+		t.Error("expected non-nil cmd to load holdings for new selection")
+	}
+}
+
+func TestEditPortfolioDialogShowsCurrentName(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.width = 100
+	m.height = 30
+	m.portfolios = []store.Portfolio{
+		{ID: 1, Name: "Test Portfolio"},
+	}
+	ti := textinput.New()
+	ti.SetValue("Test Portfolio")
+	m.mode = editingPortfolio{
+		portfolio: store.Portfolio{ID: 1, Name: "Test Portfolio"},
+		input:     ti,
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "Test Portfolio") {
+		t.Error("expected edit dialog to show portfolio name")
+	}
+}
+
+func TestDeletePortfolioDialogShowsName(t *testing.T) {
+	m := NewPortfolioModel(testCtx, &StubStore{})
+	m.width = 100
+	m.height = 30
+	m.portfolios = []store.Portfolio{
+		{ID: 1, Name: "Test Portfolio"},
+	}
+	m.mode = deletingPortfolio{
+		portfolio: store.Portfolio{ID: 1, Name: "Test Portfolio"},
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "Test Portfolio") {
+		t.Error("expected delete dialog to show portfolio name")
 	}
 }
 

--- a/internal/ui/testhelpers_test.go
+++ b/internal/ui/testhelpers_test.go
@@ -81,6 +81,29 @@ func (s *StubStore) GetHoldingsForPortfolio(ctx context.Context, portfolioID int
 	return s.holdingRows, nil
 }
 
+func (s *StubStore) RenamePortfolio(ctx context.Context, id int64, name string) error {
+	if s.err != nil {
+		return s.err
+	}
+	for i, p := range s.portfolios {
+		if p.ID == id {
+			s.portfolios[i].Name = name
+			return nil
+		}
+	}
+	return nil
+}
+
+func (s *StubStore) DeletePortfolio(ctx context.Context, id int64) error {
+	for i, p := range s.portfolios {
+		if p.ID == id {
+			s.portfolios = append(s.portfolios[:i], s.portfolios[i+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
 // StubAPI implements api.CoinGeckoClient for testing
 type StubAPI struct {
 	coins             []store.Coin


### PR DESCRIPTION
## Summary

- Add edit portfolio name (`e`) and delete portfolio (`X`) interactions in the portfolio panel
- Add `RenamePortfolio` and `DeletePortfolio` to the `Store` interface and `SQLiteStore` implementation
- Add `UNIQUE` constraint on `portfolios.name` to enforce uniqueness at the DB level
- Full test coverage: rename happy path, duplicate name rejection, not-found, cascade delete on holdings

## Test Plan

- [x] `e` on a portfolio opens edit dialog pre-filled with current name; `Enter` saves, `Esc` cancels
- [x] Renaming to an existing portfolio name shows error and does not save
- [x] `X` on a portfolio opens delete confirmation; `Enter` deletes with holdings, `Esc` cancels
- [x] `make test` passes with race detector clean