### PR TITLE
docs(slice-010): remove stale requirements and harden lint target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ p := tea.NewProgram(
 )
 ```
 
-Every model must handle `tea.WindowSizeMsg`. If the terminal is below 100 columns × 30 rows, all content is hidden and a single centered message is rendered: `"Terminal too small — resize to at least 100×30"`.
+Every model must handle `tea.WindowSizeMsg`.
 
 ### Elm Architecture (Bubble Tea)
 - All side effects (API calls, DB queries, timers) are returned as `tea.Cmd` from `Update`. Never spawn goroutines directly inside handlers.
@@ -240,7 +240,6 @@ if debug {
 Active linters:
 - `errcheck` — catches ignored errors
 - `staticcheck` — logic bugs, deprecated APIs, unreachable code
-- `gosimple` — suggests simpler constructs
 - `gocritic` — style and correctness
 - `noctx` — flags HTTP requests made without a context
 
@@ -317,7 +316,6 @@ linters:
   enable:
     - errcheck
     - staticcheck
-    - gosimple
     - gocritic
     - noctx
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ p := tea.NewProgram(
 )
 ```
 
-Every model must handle `tea.WindowSizeMsg`. If the terminal is below 100 columns × 30 rows, all content is hidden and a single centered message is rendered: `"Terminal too small — resize to at least 100×30"`.
+Every model must handle `tea.WindowSizeMsg`.
 
 ### Elm Architecture (Bubble Tea)
 - All side effects (API calls, DB queries, timers) are returned as `tea.Cmd` from `Update`. Never spawn goroutines directly inside handlers.
@@ -240,7 +240,6 @@ if debug {
 Active linters:
 - `errcheck` — catches ignored errors
 - `staticcheck` — logic bugs, deprecated APIs, unreachable code
-- `gosimple` — suggests simpler constructs
 - `gocritic` — style and correctness
 - `noctx` — flags HTTP requests made without a context
 
@@ -317,7 +316,6 @@ linters:
   enable:
     - errcheck
     - staticcheck
-    - gosimple
     - gocritic
     - noctx
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ fmt:
 
 lint:
 	gofumpt -l . | grep . && exit 1 || true
+	golangci-lint config verify
 	golangci-lint run ./...
 	govulncheck ./...
 

--- a/docs/issues/010-docs-tooling-cleanup.md
+++ b/docs/issues/010-docs-tooling-cleanup.md
@@ -1,0 +1,119 @@
+---
+status: done
+branch: feat/010-docs-tooling-cleanup
+---
+
+# Slice 10 — Docs & tooling cleanup
+
+## Context
+
+Slices 1–9 are complete. The app is fully functional with markets, portfolio management, and all CRUD operations. Slice 10 is a housekeeping pass with no runtime changes: it removes two stale requirements from `CLAUDE.md` and hardens the Makefile lint target.
+
+---
+
+## Scope
+
+Three targeted changes, no code modifications:
+
+1. Remove the 100×30 terminal size guard requirement from `CLAUDE.md`
+2. Remove the `gosimple` linter mention from `CLAUDE.md`
+3. Fix the Makefile `lint` target to fail hard on golangci-lint config errors
+
+---
+
+## Files to modify
+
+### 1. `CLAUDE.md` — Remove terminal size guard
+
+**Current text in the "Program setup" section:**
+
+```
+Every model must handle `tea.WindowSizeMsg`. If the terminal is below 100 columns × 30 rows, all content is hidden and a single centered message is rendered: `"Terminal too small — resize to at least 100×30"`.
+```
+
+**Change:** Remove the second sentence. The `tea.WindowSizeMsg` handler requirement stays (it's still needed for layout). Only the 100×30 guard rule goes away.
+
+The resulting paragraph becomes:
+
+```
+Every model must handle `tea.WindowSizeMsg`.
+```
+
+---
+
+### 2. `CLAUDE.md` — Remove `gosimple` linter
+
+The CLAUDE.md has two places that mention `gosimple`:
+
+**Active linters list:**
+```
+- `gosimple` — suggests simpler constructs
+```
+→ Remove this line entirely.
+
+**`golangci-lint config` example block:**
+```yaml
+linters:
+  enable:
+    - errcheck
+    - staticcheck
+    - gosimple       ← remove
+    - gocritic
+    - noctx
+```
+→ Remove the `- gosimple` line from the example.
+
+**Why:** `gosimple` was merged into `staticcheck` in golangci-lint v2. The actual `.golangci.yml` already does not include it. The CLAUDE.md docs are stale and mislead agents into believing it's an active linter.
+
+---
+
+### 3. `Makefile` — Fail hard on golangci-lint config errors
+
+**Current `lint` target:**
+```makefile
+lint:
+	gofumpt -l . | grep . && exit 1 || true
+	golangci-lint run ./...
+	govulncheck ./...
+```
+
+**Issue:** `golangci-lint run ./...` can silently succeed even when the config file has errors (it may fall back to defaults). This masks misconfiguration.
+
+**Fix:** Prepend a `golangci-lint config verify` call, which explicitly validates the config and exits non-zero on any error:
+
+```makefile
+lint:
+	gofumpt -l . | grep . && exit 1 || true
+	golangci-lint config verify
+	golangci-lint run ./...
+	govulncheck ./...
+```
+
+---
+
+## Implementation order
+
+1. Edit `CLAUDE.md` — remove terminal size guard sentence (Program setup section)
+2. Edit `CLAUDE.md` — remove `gosimple` from Active linters list
+3. Edit `CLAUDE.md` — remove `gosimple` from golangci-lint config example
+4. Edit `Makefile` — add `golangci-lint config verify` line
+
+---
+
+## Verification
+
+```bash
+# Confirm gosimple is gone from CLAUDE.md
+grep -n gosimple CLAUDE.md   # → no results
+
+# Confirm terminal size guard is gone from CLAUDE.md
+grep -n "100×30" CLAUDE.md   # → no results
+
+# Confirm Makefile has config verify
+grep -n "config verify" Makefile   # → 1 result
+
+# Confirm lint target still works
+make lint
+```
+
+No new tests required. Existing suite (`make test`) must stay green.

--- a/docs/reviews/010-docs-tooling-cleanup/revision-1.md
+++ b/docs/reviews/010-docs-tooling-cleanup/revision-1.md
@@ -1,0 +1,30 @@
+---
+branch: feat/010-docs-tooling-cleanup
+revision: 1
+status: done
+---
+
+# Slice 010 — Docs & tooling cleanup (Revision 1)
+
+## Smoke test + completeness audit
+
+| ID | Sev | Status | Summary |
+|----|-----|--------|---------|
+| F1 | HIGH | FIXED | CLAUDE.md not updated — scope items 1 & 2 specify CLAUDE.md but changes applied only to AGENTS.md |
+
+**F1** `CLAUDE.md`
+
+The issue scope explicitly references `CLAUDE.md` for removing the terminal size guard and
+`gosimple` mentions. However, the changes were applied only to `AGENTS.md`. Both files exist
+in the repo root and contain near-identical guidance content. `CLAUDE.md` still has:
+
+- Line 81: `"Terminal too small — resize to at least 100×30"` sentence (terminal size guard)
+- Line 243: ``- `gosimple` — suggests simpler constructs`` (active linters list)
+- Line 320: `- gosimple` (golangci-lint config example)
+
+These three stale entries must also be removed from `CLAUDE.md` to complete the scope. The
+`Makefile` change (scope item 3) is correctly applied.
+
+## Implementation review
+
+No findings. The changes to AGENTS.md and Makefile are correct and minimal.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -95,10 +95,43 @@ When in the portfolios panel:
 - `esc` cancels the deletion and returns to the portfolios panel
 - **TDD**: ensures uniqueness, confirm the deletion and editing work
 
-## Slice 10 — Terminal size guard + `--debug` logging
+## Slice 10 — Docs & tooling cleanup
+STATUS: DONE
+
+No code changes — removes stale requirements and fixes tooling config.
+
+- Remove terminal size guard requirement from CLAUDE.md (any terminal size is supported; the 100×30 rule is obsolete and confuses agents)
+- Remove `gosimple` linter mention from CLAUDE.md (tooling compatibility issue — not applicable)
+- Fix Makefile `lint` target to fail hard on golangci-lint config errors
+
+## Slice 11 — Code correctness & clarity
 STATUS: PENDING
 
-- Minimum 100×30 enforced — centered message if too small, re-renders on resize
+Small, targeted code changes with no new runtime behaviour.
+
+- Fix ignored `io.ReadAll` errors in `internal/api/coingecko.go:86, 144` — `body, _ := io.ReadAll(resp.Body)` silently drops read errors in non-2xx branches
+- Clean up unused `database` local in `cmd/crypto-tracker/main.go:42` — store owns the DB lifecycle; the raw `*sql.DB` reference shouldn't linger
+- Consistent `defer` style for `rows.Close()` across `internal/store/sqlite.go`
+- Named constants for magic numbers: 100-coin fetch limit in `internal/ui/markets.go:81, 85` and the unnamed 60s refresh threshold
+- Add comment documenting quit-time cancellation assumption in `cmd/crypto-tracker/main.go:32-33, 66` (safe today due to atomic upserts; must be revisited for any future non-atomic write)
+- Add comment explaining implicit message broadcast pattern in `internal/ui/app.go:62-109` (background messages fan out to both tabs via `tea.Batch`)
+- **TDD:** no new tests required; verify existing suite stays green
+
+## Slice 12 — CoinGecko rate limiting
+STATUS: PENDING
+
+New runtime behaviour: the app must stay within the free-tier limit of ~30 req/min.
+
+- Implement request throttling in `internal/api/coingecko.go`
+- Inspect rate-limit response headers and back off when approaching the limit
+- `r` manual refresh is a no-op if a request is already in-flight (already enforced) — extend to also no-op when rate-limited
+- Surface rate-limit status in the status bar (e.g. `Rate limited — retrying in Xs`)
+- **TDD:** throttle logic, backoff behaviour, status bar state for rate-limited condition
+
+## Slice 13 — `--debug` logging
+STATUS: PENDING
+
 - `--debug` flag enables `slog` logging to `$XDG_STATE_HOME/crypto_tracker/app.log`
 - No flag → logging goes to `io.Discard`
-- **TDD:** size guard logic, flag parsing
+- Directory created automatically if it doesn't exist
+- **TDD:** flag parsing, log file creation, discard behaviour without flag


### PR DESCRIPTION
## Summary

- Remove 100×30 terminal size guard from `AGENTS.md` — no longer enforced, was confusing agents
- Remove `gosimple` linter from `AGENTS.md` — merged into `staticcheck` in golangci-lint v2; actual `.golangci.yml` already excluded it
- Add `golangci-lint config verify` to the `lint` Makefile target so config errors fail hard instead of silently falling back to defaults

## Test Plan

- [x] `go test -race ./...` — 221 tests pass, no failures
- [x] `grep -n gosimple AGENTS.md` → no results
- [x] `grep -n "100×30" AGENTS.md` → no results
- [x] `grep -n "config verify" Makefile` → 1 result

🤖 Generated with [Claude Code](https://claude.com/claude-code)