### PR TITLE
fix(slice-011): code correctness and clarity improvements

### DIFF
--- a/cmd/crypto-tracker/main.go
+++ b/cmd/crypto-tracker/main.go
@@ -29,6 +29,10 @@ func realMain() int {
 	cleanup := setupLogger(*debug)
 	defer cleanup()
 
+	// Root context is cancelled on SIGINT/SIGTERM, propagating cancellation to
+	// all in-flight HTTP requests and DB queries. This is safe because every DB
+	// write is an atomic upsert — there is no risk of partial or corrupt data on
+	// abrupt shutdown. Must revisit if multi-statement transactions are added.
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
@@ -39,6 +43,8 @@ func realMain() int {
 		return 1
 	}
 
+	// The raw *sql.DB handle is passed to the store and not used directly after
+	// this point. The store owns the DB lifecycle (including Close via defer below).
 	database, err := db.Open(ctx, dbPath)
 	if err != nil {
 		slog.Error("opening database", "error", err)

--- a/docs/issues/011-code-correctness-clarity.md
+++ b/docs/issues/011-code-correctness-clarity.md
@@ -1,0 +1,151 @@
+---
+status: in_review
+branch: feat/011-code-correctness-clarity
+---
+
+# Slice 11 — Code correctness & clarity
+
+Small, targeted code changes with no new runtime behaviour.
+
+## Context
+
+Slices 1–10 are DONE. The app has a working markets tab, portfolio tab with full CRUD, auto-refresh, and status bar. This slice fixes bugs, cleans up inconsistencies, adds documentation comments, and names magic numbers.
+
+## Scope
+
+1. Fix ignored `io.ReadAll` errors in `internal/api/coingecko.go:86, 144`
+2. Clean up unused `database` local in `cmd/crypto-tracker/main.go:42` — add lifecycle-ownership comment
+3. Named constants for magic numbers: 100-coin fetch limit and 60s refresh threshold in `internal/ui/markets.go`
+4. Add comment documenting quit-time cancellation assumption in `cmd/crypto-tracker/main.go:32-33, 66`
+5. Add comment explaining implicit message broadcast pattern in `internal/ui/app.go:102-108`
+
+## Data model
+
+No schema changes.
+
+## Files to modify
+
+### 1. `internal/api/coingecko.go`
+
+**Fix silently dropped `io.ReadAll` errors in non-2xx branches.**
+
+Lines 86 and 144 both do `body, _ := io.ReadAll(resp.Body)` — the `_` silently discards potential read errors. If reading the body fails, the status code is reported but the body content is empty or truncated, producing a misleading error message.
+
+**Change in `FetchMarkets`:** Replace lines ~85-88:
+
+```go
+// Before:
+if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+    body, _ := io.ReadAll(resp.Body)
+    return nil, fmt.Errorf("fetching markets: %d %s", resp.StatusCode, string(body))
+}
+
+// After:
+if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+    body, readErr := io.ReadAll(resp.Body)
+    if readErr != nil {
+        return nil, fmt.Errorf("fetching markets: %d (failed to read response body: %w)", resp.StatusCode, readErr)
+    }
+    return nil, fmt.Errorf("fetching markets: %d %s", resp.StatusCode, string(body))
+}
+```
+
+**Change in `FetchPrices`:** Same pattern at lines ~143-146:
+
+```go
+// Before:
+if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+    body, _ := io.ReadAll(resp.Body)
+    return nil, fmt.Errorf("fetching prices: %d %s", resp.StatusCode, string(body))
+}
+
+// After:
+if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+    body, readErr := io.ReadAll(resp.Body)
+    if readErr != nil {
+        return nil, fmt.Errorf("fetching prices: %d (failed to read response body: %w)", resp.StatusCode, readErr)
+    }
+    return nil, fmt.Errorf("fetching prices: %d %s", resp.StatusCode, string(body))
+}
+```
+
+### 2. `internal/ui/markets.go`
+
+**Replace magic numbers with named constants.**
+
+Add at package level (near `staleThreshold`):
+
+```go
+const (
+    coinFetchLimit   = 100
+    refreshInterval  = 60 * time.Second
+    staleThreshold   = 5 * time.Minute // already exists, include in group
+)
+```
+
+Remove the existing standalone `staleThreshold` const since it moves into this block.
+
+**Update `cmdLoad`:** Line 81 (`len(existing) >= 100` → `len(existing) >= coinFetchLimit`) and line 85 (`m.client.FetchMarkets(m.ctx, 100)` → `m.client.FetchMarkets(m.ctx, coinFetchLimit)`).
+
+**Update tick handler:** Line 140 (`time.Since(m.lastRefreshed) >= 60*time.Second` → `time.Since(m.lastRefreshed) >= refreshInterval`).
+
+### 3. `cmd/crypto-tracker/main.go`
+
+**Add two documentation comments.**
+
+**Comment 1 — Cancellation safety:** Above `ctx, cancel := signal.NotifyContext(...)` (lines 32-33), add:
+
+```go
+// Root context is cancelled on SIGINT/SIGTERM, propagating cancellation to
+// all in-flight HTTP requests and DB queries. This is safe because every DB
+// write is an atomic upsert — there is no risk of partial or corrupt data on
+// abrupt shutdown. Must revisit if multi-statement transactions are added.
+```
+
+**Comment 2 — Lifecycle ownership:** Above `database, err := db.Open(...)` (line 42), add:
+
+```go
+// The raw *sql.DB handle is passed to the store and not used directly after
+// this point. The store owns the DB lifecycle (including Close via defer below).
+```
+
+### 4. `internal/ui/app.go`
+
+**Add comment explaining broadcast pattern.** Above the fan-out block (lines ~102-108), add:
+
+```go
+// Background messages (non-key, non-resize) are always forwarded to both
+// children via tea.Batch. This ensures that async responses like
+// coinsLoadedMsg and pricesUpdatedMsg reach whichever tab issued the
+// command, even if the user has since switched tabs. Without this
+// broadcast, responses would be silently dropped when the inactive tab
+// doesn't match the issuing tab.
+```
+
+## Tests
+
+No new tests required. Verify existing suite stays green via `make test`.
+
+## Implementation order
+
+1. `internal/api/coingecko.go` — Fix `io.ReadAll` error handling
+2. `internal/ui/markets.go` — Named constants for magic numbers
+3. `cmd/crypto-tracker/main.go` — Documentation comments
+4. `internal/ui/app.go` — Broadcast-pattern comment
+5. `make check` — verify all tests pass, lint clean, no vet errors
+
+## Verification
+
+```bash
+make fmt
+make lint
+make test
+make vuln
+make build
+```
+
+All must pass. No new test files. No new runtime behaviour.
+
+## Branch name
+
+`feat/011-code-correctness-clarity`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -105,7 +105,7 @@ No code changes — removes stale requirements and fixes tooling config.
 - Fix Makefile `lint` target to fail hard on golangci-lint config errors
 
 ## Slice 11 — Code correctness & clarity
-STATUS: PENDING
+STATUS: IN_REVIEW
 
 Small, targeted code changes with no new runtime behaviour.
 

--- a/internal/api/coingecko.go
+++ b/internal/api/coingecko.go
@@ -83,7 +83,10 @@ func (c *HTTPClient) FetchMarkets(ctx context.Context, limit int) ([]store.Coin,
 	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return nil, fmt.Errorf("fetching markets: %d (failed to read response body: %w)", resp.StatusCode, readErr)
+		}
 		return nil, fmt.Errorf("fetching markets: %d %s", resp.StatusCode, string(body))
 	}
 
@@ -141,7 +144,10 @@ func (c *HTTPClient) FetchPrices(ctx context.Context, apiIDs []string) (map[stri
 	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return nil, fmt.Errorf("fetching prices: %d (failed to read response body: %w)", resp.StatusCode, readErr)
+		}
 		return nil, fmt.Errorf("fetching prices: %d %s", resp.StatusCode, string(body))
 	}
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -99,9 +99,12 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	// Fan out background messages (non-key, non-resize) to both children
-	// so async responses like portfoliosLoadedMsg aren't dropped when the
-	// other tab is active.
+	// Background messages (non-key, non-resize) are always forwarded to both
+	// children via tea.Batch. This ensures that async responses like
+	// coinsLoadedMsg and pricesUpdatedMsg reach whichever tab issued the
+	// command, even if the user has since switched tabs. Without this
+	// broadcast, responses would be silently dropped when the inactive tab
+	// doesn't match the issuing tab.
 	var cmd1, cmd2 tea.Cmd
 	m.markets, cmd1 = m.markets.update(msg)
 	m.portfolio, cmd2 = m.portfolio.update(msg)

--- a/internal/ui/markets.go
+++ b/internal/ui/markets.go
@@ -47,8 +47,11 @@ type pricesUpdatedMsg struct {
 // tickMsg fires every 5 seconds from cmdTick.
 type tickMsg time.Time
 
-// staleThreshold is the duration after which data is considered stale.
-const staleThreshold = 5 * time.Minute
+const (
+	coinFetchLimit  = 100
+	refreshInterval = 60 * time.Second
+	staleThreshold  = 5 * time.Minute
+)
 
 // NewMarketsModel creates a new MarketsModel with the given dependencies.
 func NewMarketsModel(ctx context.Context, s store.Store, c api.CoinGeckoClient) MarketsModel {
@@ -78,11 +81,11 @@ func (m MarketsModel) cmdLoad() tea.Cmd {
 		if err != nil {
 			return errMsg{err: fmt.Errorf("loading coins: %w", err)}
 		}
-		if len(existing) >= 100 {
+		if len(existing) >= coinFetchLimit {
 			return coinsLoadedMsg{coins: existing}
 		}
 
-		fetched, err := m.client.FetchMarkets(m.ctx, 100)
+		fetched, err := m.client.FetchMarkets(m.ctx, coinFetchLimit)
 		if err != nil {
 			return errMsg{err: err}
 		}
@@ -137,7 +140,7 @@ func (m MarketsModel) update(msg tea.Msg) (MarketsModel, tea.Cmd) {
 		m.height = msg.Height
 	case tickMsg:
 		cmds := []tea.Cmd{cmdTick()}
-		if !m.refreshing && len(m.coins) > 0 && time.Since(m.lastRefreshed) >= 60*time.Second {
+		if !m.refreshing && len(m.coins) > 0 && time.Since(m.lastRefreshed) >= refreshInterval {
 			m.refreshing = true
 			cmds = append(cmds, m.cmdRefresh())
 		}


### PR DESCRIPTION
## Summary

- Fix silently dropped `io.ReadAll` errors in `internal/api/coingecko.go` — both `FetchMarkets` and `FetchPrices` now propagate read errors from non-2xx response bodies instead of ignoring them
- Replace magic numbers with named constants in `internal/ui/markets.go` — `coinFetchLimit` (100), `refreshInterval` (60s), grouped alongside existing `staleThreshold`
- Add documentation comments in `cmd/crypto-tracker/main.go` — cancellation safety assumption for shutdown and DB lifecycle ownership
- Expand comment explaining the background message broadcast pattern in `internal/ui/app.go`

## Test Plan

- [x] `make check` passes (fmt, lint, test, vuln)
- [x] Error messages from CoinGecko client still include status code and body when available
- [x] No change in runtime behaviour — constants match previous literal values