### PR TITLE
feat(slice-013): Settings tab + currency data layer

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -14,6 +14,8 @@ structured review document and report findings to the user.
 
 **Announce at start:** "Using the qa skill to review the current IN_REVIEW slice."
 
+**IMPORTANT**: this skill is used to FIND and REPORT bugs. You DO NOT fix, explore fixes or try to find solutions. You simply find bugs and point them out. The fix agent will be responsible for fixing the errors. DO NOT waste tokens and context looking for solutions for the fixes!!! FOCUS ONLY on finding and understanding the bugs. Point to relevant files and lines but forget about planning or finding a fix.
+
 ## Workflow
 
 ```dot

--- a/docs/issues/013-settings-tab-currency-data-layer.md
+++ b/docs/issues/013-settings-tab-currency-data-layer.md
@@ -1,0 +1,506 @@
+---
+status: in_review
+branch: feat/013-settings-tab-currency-data-layer
+---
+
+# Slice 13 — Settings tab + currency data layer
+
+## Context
+
+Slices 1–12 are complete. The app has a working Markets tab (100 coins, auto-refresh, status bar, rate limiting) and a Portfolio tab (CRUD for portfolios and holdings). All data is hardcoded to USD. Slice 13 adds the **Settings tab** infrastructure: new DB tables for currencies and settings, a CoinGecko API method to fetch supported currencies, fiat filtering, and the Settings UI with a currency picker (browsing + picking modes). Currency **selection** (writing to settings and re-fetching in the new currency) is explicitly deferred to Slice 14 — `Enter` in the picker does nothing yet.
+
+## Scope
+
+1. `currencies` and `settings` DB tables via `schema.sql`
+2. `Currency` type + `UpsertCurrencies` / `GetAllCurrencies` / `GetSetting` / `SetSetting` on the `Store` interface and `SQLiteStore`
+3. `CoinGeckoClient.FetchSupportedCurrencies(ctx) ([]string, error)` + HTTP implementation
+4. `internal/api/fiat.go` — hardcoded map of ~35 fiat currencies (code → display name)
+5. On-first-launch async fetch: `FetchSupportedCurrencies` → filter against fiat map → `UpsertCurrencies`
+6. `selected_currency = "usd"` seeded on DB init
+7. `internal/ui/settings.go` — `SettingsModel` with `browsing` and `picking` modes
+8. `AppModel` gains 3rd tab, `3` key, updated tab bar
+9. `InputActive()` on `SettingsModel` suppresses tab switching when picker is open
+
+## Data model
+
+### `currencies` table
+
+```sql
+CREATE TABLE IF NOT EXISTS currencies (
+    code TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL
+);
+```
+
+### `settings` table
+
+```sql
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT NOT NULL UNIQUE,
+    value TEXT NOT NULL
+);
+```
+
+Default setting seeded in `db.go` `Open()`:
+
+```sql
+INSERT OR IGNORE INTO settings (key, value) VALUES ('selected_currency', 'usd');
+```
+
+### `Currency` struct (`internal/store/store.go`)
+
+```go
+type Currency struct {
+    Code string
+    Name string
+}
+```
+
+## Files to create/modify
+
+### `internal/db/schema.sql` — add two tables + seed
+
+Add at end of file:
+
+```sql
+CREATE TABLE IF NOT EXISTS currencies (
+    code TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT NOT NULL UNIQUE,
+    value TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO settings (key, value) VALUES ('selected_currency', 'usd');
+```
+
+### `internal/store/store.go` — add `Currency` type + 4 new interface methods
+
+```go
+type Currency struct {
+    Code string
+    Name string
+}
+
+type Store interface {
+    // ... existing methods ...
+
+    UpsertCurrencies(ctx context.Context, currencies []Currency) error
+    GetAllCurrencies(ctx context.Context) ([]Currency, error)
+    GetSetting(ctx context.Context, key string) (string, error)
+    SetSetting(ctx context.Context, key, value string) error
+}
+```
+
+### `internal/store/sqlite.go` — implement 4 new methods
+
+**`UpsertCurrencies`** — inserts or updates each currency in a transaction:
+
+```go
+func (s *SQLiteStore) UpsertCurrencies(ctx context.Context, currencies []Currency) error {
+    if len(currencies) == 0 {
+        return nil
+    }
+    tx, err := s.db.BeginTx(ctx, nil)
+    if err != nil {
+        return fmt.Errorf("beginning transaction: %w", err)
+    }
+    defer func() { _ = tx.Rollback() }()
+
+    stmt, err := tx.PrepareContext(ctx, `
+        INSERT INTO currencies (code, name) VALUES (?, ?)
+        ON CONFLICT(code) DO UPDATE SET name = excluded.name
+    `)
+    if err != nil {
+        return fmt.Errorf("preparing upsert statement: %w", err)
+    }
+    defer func() { _ = stmt.Close() }()
+
+    for _, c := range currencies {
+        if _, err := stmt.ExecContext(ctx, c.Code, c.Name); err != nil {
+            return fmt.Errorf("upserting currency %s: %w", c.Code, err)
+        }
+    }
+
+    if err := tx.Commit(); err != nil {
+        return fmt.Errorf("committing transaction: %w", err)
+    }
+    return nil
+}
+```
+
+**`GetAllCurrencies`** — returns all currencies ordered by code:
+
+```go
+func (s *SQLiteStore) GetAllCurrencies(ctx context.Context) ([]Currency, error) {
+    rows, err := s.db.QueryContext(ctx, `SELECT code, name FROM currencies ORDER BY code ASC`)
+    if err != nil {
+        return nil, fmt.Errorf("querying currencies: %w", err)
+    }
+    defer func() { _ = rows.Close() }()
+
+    currencies := make([]Currency, 0)
+    for rows.Next() {
+        var c Currency
+        if err := rows.Scan(&c.Code, &c.Name); err != nil {
+            return nil, fmt.Errorf("scanning currency: %w", err)
+        }
+        currencies = append(currencies, c)
+    }
+    if err := rows.Err(); err != nil {
+        return nil, fmt.Errorf("iterating currencies: %w", err)
+    }
+    return currencies, nil
+}
+```
+
+**`GetSetting`** — returns value or empty string if not found:
+
+```go
+func (s *SQLiteStore) GetSetting(ctx context.Context, key string) (string, error) {
+    var value string
+    err := s.db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, key).Scan(&value)
+    if errors.Is(err, sql.ErrNoRows) {
+        return "", nil
+    }
+    if err != nil {
+        return "", fmt.Errorf("getting setting %q: %w", key, err)
+    }
+    return value, nil
+}
+```
+
+**`SetSetting`** — upserts a setting:
+
+```go
+func (s *SQLiteStore) SetSetting(ctx context.Context, key, value string) error {
+    _, err := s.db.ExecContext(ctx, `
+        INSERT INTO settings (key, value) VALUES (?, ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+    `, key, value)
+    if err != nil {
+        return fmt.Errorf("setting %q: %w", key, err)
+    }
+    return nil
+}
+```
+
+### `internal/api/fiat.go` — hardcoded fiat currency map + filter function
+
+~35 world fiat currencies with code → display name. Intersection with `/simple/supported_vs_currencies` response determines what we store.
+
+```go
+package api
+
+var FiatCurrencies = map[string]string{
+    "usd": "US Dollar",
+    "eur": "Euro",
+    "gbp": "British Pound",
+    "jpy": "Japanese Yen",
+    "aud": "Australian Dollar",
+    "cad": "Canadian Dollar",
+    "chf": "Swiss Franc",
+    "cny": "Chinese Yuan",
+    "inr": "Indian Rupee",
+    "krw": "South Korean Won",
+    "brl": "Brazilian Real",
+    "rub": "Russian Ruble",
+    "mxn": "Mexican Peso",
+    "sek": "Swedish Krona",
+    "nok": "Norwegian Krone",
+    "dkk": "Danish Krone",
+    "nzd": "New Zealand Dollar",
+    "sgd": "Singapore Dollar",
+    "hkd": "Hong Kong Dollar",
+    "pln": "Polish Zloty",
+    "thb": "Thai Baht",
+    "twd": "Taiwan Dollar",
+    "czk": "Czech Koruna",
+    "ils": "Israeli Shekel",
+    "zar": "South African Rand",
+    "php": "Philippine Peso",
+    "try": "Turkish Lira",
+    "idr": "Indonesian Rupiah",
+    "myr": "Malaysian Ringgit",
+    "ars": "Argentine Peso",
+    "clp": "Chilean Peso",
+    "vnd": "Vietnamese Dong",
+    "aed": "UAE Dirham",
+    "sar": "Saudi Riyal",
+}
+
+func FilterFiat(apiCodes []string) []string {
+    result := make([]string, 0, len(apiCodes))
+    for _, code := range apiCodes {
+        if _, ok := FiatCurrencies[code]; ok {
+            result = append(result, code)
+        }
+    }
+    return result
+}
+```
+
+### `internal/api/coingecko.go` — add `FetchSupportedCurrencies`
+
+Add to `CoinGeckoClient` interface:
+
+```go
+type CoinGeckoClient interface {
+    FetchMarkets(ctx context.Context, limit int) ([]store.Coin, error)
+    FetchPrices(ctx context.Context, apiIDs []string) (map[string]float64, error)
+    FetchSupportedCurrencies(ctx context.Context) ([]string, error)
+}
+```
+
+HTTP implementation:
+
+```go
+func (c *HTTPClient) FetchSupportedCurrencies(ctx context.Context) ([]string, error) {
+    if err := c.throttle(ctx); err != nil {
+        return nil, err
+    }
+
+    u := c.baseURL + "/simple/supported_vs_currencies"
+
+    req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
+    if err != nil {
+        return nil, fmt.Errorf("creating request: %w", err)
+    }
+
+    if c.apiKey != "" {
+        req.Header.Set("x-cg-demo-api-key", c.apiKey)
+    }
+
+    resp, err := c.httpClient.Do(req)
+    if err != nil {
+        return nil, fmt.Errorf("fetching supported currencies: %w", err)
+    }
+    defer func() { _ = resp.Body.Close() }()
+
+    if resp.StatusCode == http.StatusTooManyRequests {
+        body, readErr := io.ReadAll(resp.Body)
+        if readErr != nil {
+            return nil, fmt.Errorf("fetching supported currencies: %d (failed to read response body: %w)", resp.StatusCode, readErr)
+        }
+        return nil, &RateLimitError{Body: string(body)}
+    }
+
+    if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+        body, readErr := io.ReadAll(resp.Body)
+        if readErr != nil {
+            return nil, fmt.Errorf("fetching supported currencies: %d (failed to read response body: %w)", resp.StatusCode, readErr)
+        }
+        return nil, fmt.Errorf("fetching supported currencies: %d %s", resp.StatusCode, string(body))
+    }
+
+    var codes []string
+    if err := json.NewDecoder(resp.Body).Decode(&codes); err != nil {
+        return nil, fmt.Errorf("decoding response: %w", err)
+    }
+
+    return codes, nil
+}
+```
+
+### `internal/ui/settings.go` — `SettingsModel`
+
+Discriminated union for modes:
+
+```go
+type settingsMode interface{ isSettingsMode() }
+
+type settingsBrowsing struct{}
+type settingsPicking struct {
+    filter   textinput.Model
+    all      []store.Currency
+    filtered []store.Currency
+    cursor   int
+}
+
+func (settingsBrowsing) isSettingsMode() {}
+func (settingsPicking) isSettingsMode()    {}
+```
+
+`SettingsModel` struct:
+
+```go
+type SettingsModel struct {
+    ctx          context.Context
+    store        store.Store
+    client       api.CoinGeckoClient
+    width        int
+    height       int
+    mode         settingsMode
+    selectedCode string
+    currencies   []store.Currency
+    loading      bool
+    lastErr      string
+}
+```
+
+Key message types:
+
+```go
+type settingsLoadedMsg struct {
+    currencies []store.Currency
+    selected   string
+}
+
+type settingsNeedFetchMsg struct{}
+
+type currenciesFetchedMsg struct {
+    codes []string
+}
+
+type currenciesUpsertedMsg struct {
+    currencies []store.Currency
+}
+```
+
+Update logic:
+
+- `browsing` mode:
+  - `Enter` → load currencies from DB. If empty, fire `settingsNeedFetchMsg`. If available, transition to `settingsPicking`.
+  - `Esc`/`q` → no-op (handled by AppModel for tab switching)
+- `settingsNeedFetchMsg` → set `loading = true`, fire `cmdFetchCurrencies`
+- `currenciesFetchedMsg` → filter API codes by `FilterFiat`, build `[]Currency` with names from `FiatCurrencies` map, upsert to DB, transition to `settingsPicking`
+- `settingsPicking` mode:
+  - `j`/`↓` → `cursor++`, clamped
+  - `k`/`↑` → `cursor--`, clamped
+  - `Esc` → return to `settingsBrowsing`
+  - `Enter` → **no-op** (Slice 14 wires selection)
+  - Other keys → forwarded to filter `textinput.Model`; re-filter list; clamp cursor
+
+View:
+
+- `browsing`: `"Base Currency: USD"` (using `selectedCode`), status bar hint
+- `picking`: searchable dialog similar to coin picker in portfolio
+- `loading`: `"Loading currencies…"` message
+
+`InputActive()`:
+
+```go
+func (m SettingsModel) InputActive() bool {
+    _, ok := m.mode.(settingsPicking)
+    return ok
+}
+```
+
+### `internal/ui/app.go` — add `tabSettings`, `SettingsModel`
+
+```go
+const (
+    tabMarkets tab = iota
+    tabPortfolio
+    tabSettings
+)
+const tabCount = 3
+```
+
+Add `settings SettingsModel` field to `AppModel`. Update `NewAppModel` to construct `SettingsModel`. Wire into `Init`, `Update`, `View`, `renderTabBar`, `activeInputActive`.
+
+Tab bar renders `" Markets "`, `" Portfolio "`, `" Settings "` with active highlighting.
+
+`3` key switches to Settings tab. Tab/Shift+Tab cycle through all 3.
+
+### `internal/ui/testhelpers_test.go` — extend `StubStore` and `StubAPI`
+
+Add to `StubStore`:
+
+```go
+currencies []store.Currency
+settings   map[string]string
+```
+
+Implement `UpsertCurrencies`, `GetAllCurrencies`, `GetSetting`, `SetSetting`.
+
+Add to `StubAPI`:
+
+```go
+supportedCurrencies []string
+```
+
+Implement `FetchSupportedCurrencies`.
+
+### `cmd/crypto-tracker/main.go` — no change needed
+
+`NewAppModel` already takes `store.Store` and `api.CoinGeckoClient` — SettingsModel receives these through the constructor.
+
+## Tests
+
+### `internal/store/sqlite_test.go`
+
+- **`TestUpsertCurrencies`** — insert 3 currencies, read back, verify all present and ordered by code
+- **`TestUpsertCurrenciesUpdatesName`** — insert with one name, upsert with different name, verify name updated
+- **`TestUpsertCurrenciesEmpty`** — verify empty slice is no-op without error
+- **`TestGetAllCurrenciesEmpty`** — verify returns empty non-nil slice when no currencies
+- **`TestGetSettingExisting`** — verify `GetSetting("selected_currency")` returns `"usd"` after DB init (seeded)
+- **`TestGetSettingMissing`** — verify `GetSetting("nonexistent")` returns `""` without error
+- **`TestSetSettingInsert`** — set a new key, read back, verify value
+- **`TestSetSettingUpdate`** — set existing key to new value, read back, verify updated
+- **`TestDefaultCurrencySeed`** — open fresh DB, verify `selected_currency = "usd"` exists
+
+### `internal/api/coingecko_test.go`
+
+- **`TestFetchSupportedCurrenciesSuccess`** — `httptest.NewServer` returning `["usd","eur","btc"]`, verify result
+- **`TestFetchSupportedCurrenciesWithAPIKey`** — verify `x-cg-demo-api-key` header sent
+- **`TestFetchSupportedCurrencies429`** — verify returns `*RateLimitError` on 429
+- **`TestFetchSupportedCurrenciesNetworkError`** — verify network error propagated
+- **`TestFetchSupportedCurrenciesContextCancelled`** — verify context cancellation respected
+- **Verify `HTTPClient` implements `CoinGeckoClient`** — existing compile-time check updated to include new method
+
+### `internal/api/fiat_test.go` (new)
+
+- **`TestFilterFiatMatchesKnownCodes`** — verify `FilterFiat(["usd","eur","btc"])` returns only `["eur","usd"]` (sorted, btc excluded as crypto)
+- **`TestFilterFiatEmptyInput`** — verify returns empty slice
+- **`TestFilterFiatNoMatches`** — verify returns empty slice for all-crypto input
+- **`TestFilterFiatAllFiat`** — verify all fiat codes in the map pass through
+
+### `internal/ui/settings_test.go` (new)
+
+- **`TestNewSettingsModel`** — verify initial state (browsing mode, no error)
+- **`TestSettingsInputActiveFalseWhenBrowsing`** — verify `InputActive()` returns false
+- **`TestSettingsInputActiveTrueWhenPicking`** — verify `InputActive()` returns true in picking mode
+- **`TestSettingsEnterOpensPickerWhenCurrenciesAvailable`** — load currencies, press Enter, verify transition to picking mode
+- **`TestSettingsEnterTriggersFetchWhenNoCurrencies`** — with empty currencies, press Enter, verify `settingsNeedFetchMsg` is produced
+- **`TestSettingsPickJkNavigation`** — in picking mode, verify j/k move cursor
+- **`TestSettingsPickFilterReducesList`** — type filter, verify filtered list and clamped cursor
+- **`TestSettingsPickEscReturnsToBrowsing`** — verify Esc returns to browsing
+- **`TestSettingsPickEnterNoOp`** — verify Enter in picking mode is a no-op (Slice 14 wires it)
+- **`TestSettingsPickCursorClampsAtTop`** — k at cursor 0 stays at 0
+- **`TestSettingsPickCursorClampsAtBottom`** — j at end stays at end
+- **`TestSettingsBrowsingShowsSelectedCurrency`** — verify View contains the selected currency code
+
+### `internal/ui/app_test.go`
+
+- **`TestThreeKeySelectsSettings`** — verify pressing `3` switches to `tabSettings`
+- **`TestTabBarShowsSettings`** — verify View contains "Settings"
+- **`TestSettingsInputActiveSuppressesTabSwitch`** — in picking mode, Tab should not switch tabs
+- **`TestTabCyclesThroughAllThreeTabs`** — verify Tab cycles Markets → Portfolio → Settings → Markets
+- **`TestShiftTabCyclesBackwards`** — verify Shift+Tab cycles Settings → Portfolio → Markets → Settings
+
+## Implementation order (TDD-first)
+
+1. `internal/db/schema.sql` — add `currencies` and `settings` tables + seed
+2. `internal/store/store.go` — add `Currency` type + 4 interface methods
+3. `internal/store/sqlite.go` — implement `UpsertCurrencies`, `GetAllCurrencies`, `GetSetting`, `SetSetting`
+4. `internal/store/sqlite_test.go` — write + run tests for all 4 new methods + seed test
+5. `internal/api/fiat.go` — create `FiatCurrencies` map + `FilterFiat` function
+6. `internal/api/fiat_test.go` — write + run filter tests
+7. `internal/api/coingecko.go` — add `FetchSupportedCurrencies` to interface + HTTP implementation
+8. `internal/api/coingecko_test.go` — write + run tests for `FetchSupportedCurrencies`
+9. `internal/ui/settings.go` — create `SettingsModel` with browsing + picking modes
+10. `internal/ui/settings_test.go` — write + run Settings model tests
+11. `internal/ui/testhelpers_test.go` — extend `StubStore` + `StubAPI` with new methods
+12. `internal/ui/app.go` — add `tabSettings`, `SettingsModel`, wire up
+13. `internal/ui/app_test.go` — add tests for 3rd tab, tab bar, input suppression
+
+## Verification
+
+```bash
+make check
+```
+
+All tests pass, lint is clean, no race conditions. The Settings tab shows in the tab bar, `3` switches to it, `Enter` opens the currency picker (or triggers a fetch if currencies not yet loaded), `j`/`k` navigate, typing filters, `Esc` returns to browsing, `Enter` in picker is a no-op (to be wired in Slice 14).

--- a/docs/reviews/013-settings-tab-currency-data-layer/revision-1.md
+++ b/docs/reviews/013-settings-tab-currency-data-layer/revision-1.md
@@ -1,0 +1,64 @@
+---
+branch: feat/013-settings-tab-currency-data-layer
+revision: 1
+status: done
+---
+
+# Slice 013 — Settings tab + currency data layer (Revision 1)
+
+## Smoke test + completeness audit
+
+All tests pass (`make check` green), binary compiles cleanly, no panics on launch.
+
+Scope item gaps:
+
+- **Arrow keys (Up/Down) not handled in picking mode.** The issue spec says `"j"/"↓" move cursor down` and `"k"/"↑" move cursor up`. The Markets and Portfolio coin-picker both handle `tea.KeyDown`/`tea.KeyUp`. The Settings picker only handles `j`/`k` via `tea.KeyRunes` — arrow keys are silently dropped.
+
+- **Esc/q handling in browsing mode is incomplete.** The issue spec says: `"Esc"/"q" → returns to tab bar`. The browsing mode in `settings.go` has no key handler for `Esc` or `q` at all. These keys work at the `AppModel` level (`q` quits globally, `Esc` is not handled for tab switching), but `Esc` in browsing mode does not return focus to the tab bar as specified.
+
+- **Status bar hint line is missing.** Every other tab/mode in the app has a dedicated status bar at the bottom of the view with keyboard hints. The Settings tab renders hints as inline text within the content area.
+
+## Implementation review
+
+| ID  | Sev  | Status | Summary |
+|-----|------|--------|---------|
+| F1  | BLOCKER | FIXED | Picking mode drops Backspace/Delete/arrow keys — no `default` case in key handler |
+| F2  | BLOCKER | FIXED | Picking mode has no viewport/scroll management — list renders all items, appears scrolled to bottom |
+| F3  | HIGH  | FIXED | j/k consumed for navigation, cannot be typed into the filter |
+| F4  | HIGH  | FIXED | Settings view has no visual framing or layout — inconsistent with rest of the app |
+| F5  | HIGH  | FIXED | Instructions rendered inline instead of in a status bar at the bottom |
+| F6  | MED   | FIXED | Arrow keys (Up/Down) not handled in picking mode |
+| F7  | MED   | FIXED | No Esc handling in browsing mode to return to tab bar |
+| I1  | HIGH  | FIXED | cmdLoadSettings/cmdFetchCurrencies/cmdUpsertCurrencies use `context.Background()` instead of the model's `ctx` |
+| I2  | LOW   | FIXED | `currencies` table uses `code TEXT NOT NULL UNIQUE` instead of `code TEXT PRIMARY KEY` (issue spec says `code TEXT PK`) |
+| I3  | LOW   | FIXED | `FilterFiat` result is unsorted when currencies come from the API path — only DB-retrieved currencies are sorted by code |
+
+**F1** `internal/ui/settings.go:125-161`
+The `settingsPicking` key handler has cases for `KeyEscape`, `KeyEnter`, and `KeyRunes` only. There is no `default` case. Keys like `KeyBackspace`, `KeyDelete`, and `KeyDown`/`KeyUp` fall through with no action and no forwarding to `textinput.Model.Update()`. The user cannot delete characters from the filter input. The portfolio's `addCoin` mode has the correct pattern: a `default` case that delegates to `mode.filter.Update(msg)`.
+
+**F2** `internal/ui/settings.go:236-267` (`viewPicking`)
+The picker renders every currency in `picking.filtered` with no offset or viewport calculation. With ~35 fiat currencies, the list overflows the terminal and the rendered output starts from the first item — but since the cursor starts at item 0 and the terminal scrolls to fit all content, the visible area shows the bottom of the list. The Markets tab uses `m.offset`/`m.adjustViewport()` to keep the cursor visible; the Settings picker has no equivalent.
+
+**F3** `internal/ui/settings.go:134-150`
+When the user is in picking mode and presses `j` or `k`, the key is intercepted for cursor navigation and returns early. The user cannot type `j` or `k` into the filter. This differs from the portfolio coin picker where the same behavior exists (j/k navigate), but in that context the coin picker's filter uses `placeholder: "filter coins..."` and the expectation is search-by-name/ticker. For the currency picker, the same trade-off applies but the user reported being unable to filter by code containing 'j' or 'k'. The code is working as designed for navigation, but the design means you cannot search for currencies like `jpy` (Japanese Yen) by typing their code.
+
+**F4** `internal/ui/settings.go:210-233` (`viewBrowsing`) and `236-267` (`viewPicking`)
+The browsing mode renders plain unstyled lines with no panel border, no visual hierarchy, and no framing. The picking mode renders a plain list with no dialog border or centering. Every dialog in the portfolio tab uses `lipgloss.Place()` with `lipgloss.RoundedBorder()` and `lipgloss.Center` positioning. The settings tab should follow the same conventions.
+
+**F5** `internal/ui/settings.go:224-225` and `265-266`
+The browsing mode appends inline text (`"Press Enter to change currency"`, `"Press Tab to switch tabs, q to quit"`). The picking mode appends a one-liner at the bottom of the list content. Neither uses a dedicated status bar row. The Markets and Portfolio tabs both have a `renderStatusBar()` method that renders hints at the bottom of the viewport using `lipgloss.Width()`-based alignment, consistent with the app's convention.
+
+**F6** `internal/ui/settings.go:125-161`
+The issue spec says `j`/`↓` move down and `k`/`↑` move up. Only `j`/`k` (via `KeyRunes`) are handled. `tea.KeyDown` and `tea.KeyUp` are not handled in picking mode. The Markets tab and portfolio coin-picker both handle arrow keys.
+
+**F7** `internal/ui/settings.go:114-120`
+The `settingsBrowsing` key handler only processes `KeyEnter`. There is no handler for `KeyEscape`. The issue spec says `Esc` in browsing mode should return to the tab bar. Currently pressing Esc in browsing mode does nothing.
+
+**I1** `internal/ui/settings.go:277-316`
+`cmdLoadSettings`, `cmdFetchCurrencies`, and `cmdUpsertCurrencies` all create `context.Background()` inside the command closure instead of capturing the model's `m.ctx`. Per architecture conventions, the root context (cancelled on quit) should be used so that in-flight I/O is cancelled when the user quits. The Markets model correctly uses `m.ctx` in its command closures.
+
+**I2** `internal/db/schema.sql:26-29`
+The issue spec defines `code TEXT PK` but the implemented schema is `code TEXT NOT NULL UNIQUE`. While functionally equivalent in SQLite, `PRIMARY KEY` is the convention used by all other tables and is what the spec requests.
+
+**I3** `internal/api/fiat.go:45-52` + `internal/ui/settings.go:94-104`
+`FilterFiat` returns codes in the order they appear in the API response, which is not guaranteed to be sorted. When currencies are loaded from the database (via `GetAllCurrencies`), they are sorted by code (`ORDER BY code ASC`). But when loaded fresh from the API (via `currenciesFetchedMsg`), they are in whatever order the API returns. This means the list order can change between sessions.

--- a/docs/reviews/013-settings-tab-currency-data-layer/revision-2.md
+++ b/docs/reviews/013-settings-tab-currency-data-layer/revision-2.md
@@ -1,0 +1,56 @@
+---
+branch: feat/013-settings-tab-currency-data-layer
+revision: 2
+status: done
+---
+
+# Slice 013 — Settings tab + currency data layer (Revision 2)
+
+## Smoke test + completeness audit
+
+`make check` passes (fmt, lint, test, vuln all green). Binary compiles cleanly.
+
+Scope item gaps from user feedback:
+
+- **Settings browsing mode has no title and doesn't follow the panel layout convention.** The Markets tab renders a table with column headers and highlighted row. The Portfolio tab renders a two-panel bordered layout with titled panels ("Portfolios", "Holdings"). The Settings browsing mode renders "Base Currency: USD (US Dollar)" as plain unstyled text inside a single bordered panel — no section title, no row highlight, no consistent visual language.
+
+- **Browsing mode has no cursor/highlight on the current setting row.** The issue spec describes settings as a selectable list (cursor on "Base Currency" row, Enter opens picker). Currently `settingsBrowsing` renders just text — there is no indication which row is selected or that any row is interactive.
+
+- **Picking mode j/k conflict with filter typing.** Pressing `j` or `k` in picking mode navigates the cursor instead of being typed into the filter. The user reports this prevents searching for currencies like "JPY" (Japanese Yen). User requests removing j/k navigation entirely and supporting only Up/Down arrow keys. Also, the `textinput.Prompt` defaults to `"> "`, which appears as a `>` prefix in the search field — the user finds this confusing and wants it removed.
+
+## Implementation review
+
+| ID  | Sev  | Status | Summary |
+|-----|------|--------|---------|
+| F1  | HIGH | FIXED | Settings browsing mode has no title, no row highlight, no panel convention consistency |
+| F2  | HIGH | FIXED | Picking mode: j/k cannot be typed into filter — user requests arrow-only navigation |
+| F3  | MED  | FIXED | Picking mode: `>` prompt symbol in textinput is confusing; remove it |
+| I1  | HIGH | FIXED | Viewport calculation mismatch: `adjustViewport` uses `height-4` but `viewPicking` renders `height-8` visible rows |
+| I2  | MED  | FIXED | Settings model doesn't handle `errMsg` — async errors from `cmdLoadSettings`, `cmdFetchCurrencies`, `cmdUpsertCurrencies` are silently discarded |
+| I3  | LOW  | FIXED | Selected-row rendering uses `line[2:]` slicing instead of building the line with selection indicator |
+
+**F1** `internal/ui/settings.go:272-303`
+The `viewBrowsing` method renders plain text ("Base Currency: USD (US Dollar)") inside a bordered panel. It lacks: (a) a panel title consistent with other tabs (e.g. "Settings" header), (b) a highlighted/selectable row for the "Base Currency" setting item, (c) any visual indication that the row is interactive or selected. The Markets tab uses `highlight.Render(line)` for the cursor row. The Portfolio tab uses `▶` prefix and accent-colored borders for focused panels. The Settings tab should follow the same convention — render each setting as a selectable row with cursor highlight, so that when additional settings are added in future slices, the pattern is already established.
+
+**F2** `internal/ui/settings.go:156-174`
+When in `settingsPicking` mode, pressing `j` or `k` is intercepted for cursor movement and the key returns early — it never reaches the filter `textinput.Model`. This makes it impossible to search for currencies whose code contains "j" or "k" (e.g. JPY, KRW, KZT). The user's requested resolution is to remove j/k navigation entirely and only support `KeyUp`/`KeyDown` arrows for cursor movement in the currency picker, freeing j/k to be typed into the filter.
+
+**F3** `internal/ui/settings.go:207`
+`makePickingMode` creates `textinput.New()` without setting `filter.Prompt = ""`. The default `Prompt` in `bubbles/textinput` is `"> "`, which renders a `>` prefix in the search field. The user finds this confusing (it looks like a cursor indicator, not a prompt). Set `filter.Prompt = ""` to remove it.
+
+**I1** `internal/ui/settings.go:237-258` vs `305-326`
+`adjustViewport` calculates `visibleRows = height - 4` (reserving 4 lines for header, filter, viewport calculations), while `viewPicking` renders `visibleRows = m.height - 8` (reserving 8 lines for header, filter, dialog border, status). These different overhead calculations mean the scroll offset computed by `adjustViewport` will be out of sync with what's actually visible, potentially scrolling the cursor out of view.
+
+**I2** `internal/ui/settings.go:79-202`
+The `update` method handles `settingsLoadedMsg`, `settingsNeedFetchMsg`, `currenciesFetchedMsg`, and `currenciesUpsertedMsg`, but has **no case for `errMsg`**. The `cmdLoadSettings`, `cmdFetchCurrencies`, and `cmdUpsertCurrencies` commands all return `errMsg` on failure. Without handling this message type, errors are silently discarded — the `m.lastErr` field is never set and the user sees no feedback. Every other tab (Markets, Portfolio) has an `errMsg` handler that sets `lastErr` to the error string.
+
+**I3** `internal/ui/settings.go:332-340`
+The selected row in `viewPicking` is rendered by building each line as `"  %s - %s"`, then replacing the selected row with `"> " + line[2:]`. The `line[2:]` slicing assumes every line starts with exactly 2 characters and is fragile. A better approach is to build the line conditionally:
+
+```go
+if i == picking.cursor {
+    line = selectedStyle.Render(fmt.Sprintf("%s - %s", strings.ToUpper(c.Code), c.Name))
+} else {
+    line = fmt.Sprintf("  %s - %s", strings.ToUpper(c.Code), c.Name)
+}
+```

--- a/docs/reviews/013-settings-tab-currency-data-layer/revision-3.md
+++ b/docs/reviews/013-settings-tab-currency-data-layer/revision-3.md
@@ -1,0 +1,58 @@
+---
+branch: feat/013-settings-tab-currency-data-layer
+revision: 3
+status: fixed
+---
+
+# Slice 013 — Settings tab + currency data layer (Revision 3)
+
+## Smoke test + completeness audit
+
+`make check` passes (fmt, lint, test, vuln all green). Binary compiles cleanly.
+
+Scope item gaps:
+
+- **`Esc` in browsing mode is advertised but non-functional.** The status bar in browsing mode reads `"Esc back to tabs"`, implying Esc returns focus to the tab bar. The `settingsBrowsing` key handler does catch `KeyEscape` but returns `m, nil` — a no-op. Neither `SettingsModel` nor `AppModel` takes any action. The hint is a lie to the user; it should either be removed or wired to observable behavior (e.g. switch to the first tab).
+
+## Implementation review
+
+| ID  | Sev  | Status | Summary |
+|-----|------|--------|---------|
+| F1  | HIGH | FIXED  | `viewPicking` passes `m.height` to `lipgloss.Place` then appends status bar, overflowing the viewport |
+| F2  | MED  | FIXED  | Status bar hint `"Esc back to tabs"` in browsing mode is shown but Esc is a no-op |
+| F3  | MED  | FIXED  | Error is displayed twice in browsing mode — once inside the panel and again in the status bar |
+| I1  | LOW  | FIXED  | `StubStore.supportedCurrencies` field is never read by any `StubStore` method |
+| I2  | LOW  | FIXED  | `FiatCurrencies` is an exported mutable map — external packages can corrupt it |
+| I3  | LOW  | FIXED  | `adjustViewport` parameter `_ int` is explicitly discarded; the function signature is stale |
+
+**F1** `internal/ui/settings.go:362-363`
+`viewPicking` ends with:
+```go
+content := lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, dialog)
+return content + "\n" + m.renderStatusBar()
+```
+`lipgloss.Place` fills a canvas of exactly `m.height` rows. Appending `"\n" + renderStatusBar()` adds 2 further rows, overflowing the terminal viewport by 2 in alt-screen mode — the status bar is clipped and never visible. `viewBrowsing` handles this correctly: it uses `innerHeight = m.height - 3`, the border adds 2 lines, giving `m.height - 1` total before the status bar. The fix is to pass `m.height - 1` to `lipgloss.Place` so one row is left for the status bar.
+
+**F2** `internal/ui/settings.go:120-123` and `371`
+`settingsBrowsing` catches `KeyEscape` and returns `m, nil`:
+```go
+case tea.KeyEscape:
+    // Return focus to tab bar - this is handled by AppModel
+    return m, nil
+```
+The comment is incorrect — `AppModel` does not handle `Esc` for tab switching either. The browsing mode status bar (`line 371`) tells the user `"Esc back to tabs"` but pressing Esc does nothing observable. Either remove the hint from the status bar or implement the behavior (e.g. emit a `tea.Msg` that `AppModel` responds to by switching to `tabMarkets`). Leaving a described shortcut as a no-op breaks user trust.
+
+**F3** `internal/ui/settings.go:284-287` and `376-378`
+When `m.lastErr != ""`, the error is rendered in two separate places simultaneously. In `viewBrowsing` (lines 284–287), it is written into the panel content as `"Error: <msg>"` in red. Then `renderStatusBar` (lines 376–378) appends it again to the status bar as `"error: <msg>"`. A user who hits an async error sees the same message twice on screen. The error should appear in one place only; the status bar is the consistent location across all other tabs.
+
+**I1** `internal/ui/testhelpers_test.go:18`
+`StubStore` has a `supportedCurrencies []string` field (line 18) that is set in `TestSettingsEnterTriggersFetchWhenNoCurrencies` but never read by any `StubStore` method. `FetchSupportedCurrencies` belongs to `StubAPI` (line 153), not `StubStore`. The field is dead weight that creates confusion about which stub is responsible for currency fetching. Remove it.
+
+**I2** `internal/api/fiat.go:8`
+`var FiatCurrencies = map[string]string{...}` is exported and mutable. Any package can add, remove, or overwrite entries at runtime; `settings.go` reads it by key (`api.FiatCurrencies[code]`) to display currency names. A mutation would silently produce empty or wrong names with no compile-time or runtime guard. Make the map unexported (`fiatCurrencies`) — `FilterFiat` is the only required exported entry point. If `settings.go` needs name lookup, add an unexported helper `fiatCurrencyName(code string) string` in the same file.
+
+**I3** `internal/ui/settings.go:224`
+```go
+func (p *settingsPicking) adjustViewport(_ int) {
+```
+The `int` parameter was used in an earlier revision when viewport height was computed from terminal height. It was replaced by the hardcoded `maxVisibleItems = 10` constant (revision 2, I1 fix) but the parameter was left in the signature rather than removed. The two call sites pass `m.height` which is silently discarded. Remove the parameter and update the call sites (`lines 148` and `156`) accordingly.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -128,7 +128,46 @@ New runtime behaviour: the app must stay within the free-tier limit of ~30 req/m
 - Surface rate-limit status in the status bar (e.g. `Rate limited — retrying in Xs`)
 - **TDD:** throttle logic, backoff behaviour, status bar state for rate-limited condition
 
-## Slice 13 — `--debug` logging
+
+## Slice 13 — Settings tab + currency data layer
+STATUS: IN_REVIEW
+
+UI and infrastructure only — Enter does not select a currency yet.
+
+- New DB tables: `currencies (code TEXT PK, name TEXT)` and `settings (key TEXT PK, value TEXT)`
+- `CoinGeckoClient.FetchSupportedCurrencies(ctx) ([]string, error)` — new API method hitting `/simple/supported_vs_currencies`
+- Filter CoinGecko response against a hardcoded fiat currency map (`internal/api/fiat.go`) — code → display name (~35 world fiat currencies; intersection with CoinGecko response determines what we store)
+- `Store` gains: `UpsertCurrencies`, `GetAllCurrencies`, `GetSetting`, `SetSetting`
+- On first launch (no currencies in DB): async `tea.Cmd` fires `FetchSupportedCurrencies`, filters to fiat, persists to DB; Settings tab shows "Loading currencies…" until available
+- Default `selected_currency = "usd"` seeded on DB init
+- New `internal/ui/settings.go`: `SettingsModel` with two modes:
+  - **Browsing**: displays "Base Currency: USD" line, `Enter` opens picker, `Esc`/`q` returns to tab bar
+  - **Picking**: dialog with searchable `textinput.Model`, scrollable filtered list of `Currency` rows, `j`/`k` scroll, `Esc` closes dialog (no selection), `Enter` does nothing yet
+- `AppModel` gains `settings SettingsModel` and `tabSettings` (3rd tab, `tab = iota` now has 3 values)
+- Tab bar renders `Markets | Portfolio | Settings`; `3` key also switches to Settings
+- `InputActive()` on `SettingsModel` returns true when picker is open — suppresses tab switching
+- **TDD:** store CRUD for settings/currencies, API mock for `FetchSupportedCurrencies`, settings model state transitions (browsing ↔ picking), search/filter logic, fiat filtering
+
+## Slice 14 — Currency selection + correct price display
+STATUS: PENDING
+
+Full end-to-end: select a currency → re-fetch data in that currency → display everywhere with correct values and code.
+
+- `CoinGeckoClient.FetchMarkets(ctx, currency, limit)` and `FetchPrices(ctx, currency, apiIDs)` — add `currency string` parameter (replaces hardcoded `"usd"`)
+- `FetchPrices` response parsing uses dynamic key (`currency`) instead of `"usd"`
+- `format.FmtPrice(currency, v)` — `currency` prepended as uppercase code (`USD 84,321.45` / `EUR 0.001234`)
+- `format.FmtMoney(currency, v)` — same, always 2 dp (`EUR 1,500.50`)
+- Picking mode `Enter` now selects the highlighted currency:
+  - Writes `selected_currency` to `settings` table
+  - Triggers immediate `cmdRefresh` using the new currency
+  - Returns to browsing mode
+- Markets tab reads selected currency from model state and passes it through `FmtPrice`/`FmtChange`
+- Portfolio tab passes currency to `FmtPrice`/`FmtMoney` for Price, Value, and total columns
+- Auto-refresh always uses the current `selected_currency` value from DB
+- App init: read `selected_currency` from DB (default `"usd"`) before first fetch
+- **TDD:** `FmtPrice`/`FmtMoney` with different currency codes, `FetchMarkets`/`FetchPrices` with `currency` param stubs, end-to-end render assertion with non-USD currency
+
+## Slice 15 — `--debug` logging
 STATUS: PENDING
 
 - `--debug` flag enables `slog` logging to `$XDG_STATE_HOME/crypto_tracker/app.log`

--- a/internal/api/coingecko.go
+++ b/internal/api/coingecko.go
@@ -49,6 +49,7 @@ func RetryAfterFromError(err error, defaultDuration time.Duration) time.Duration
 type CoinGeckoClient interface {
 	FetchMarkets(ctx context.Context, limit int) ([]store.Coin, error)
 	FetchPrices(ctx context.Context, apiIDs []string) (map[string]float64, error)
+	FetchSupportedCurrencies(ctx context.Context) ([]string, error)
 }
 
 // HTTPClient implements CoinGeckoClient using HTTP requests.
@@ -277,4 +278,51 @@ func (c *HTTPClient) FetchPrices(ctx context.Context, apiIDs []string) (map[stri
 	}
 
 	return prices, nil
+}
+
+// FetchSupportedCurrencies fetches the list of supported vs currencies from CoinGecko.
+func (c *HTTPClient) FetchSupportedCurrencies(ctx context.Context) ([]string, error) {
+	if err := c.throttle(ctx); err != nil {
+		return nil, err
+	}
+
+	u := c.baseURL + "/simple/supported_vs_currencies"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	if c.apiKey != "" {
+		req.Header.Set("x-cg-demo-api-key", c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching supported currencies: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return nil, fmt.Errorf("fetching supported currencies: %d (failed to read response body: %w)", resp.StatusCode, readErr)
+		}
+		return nil, &RateLimitError{Body: string(body)}
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return nil, fmt.Errorf("fetching supported currencies: %d (failed to read response body: %w)", resp.StatusCode, readErr)
+		}
+		return nil, fmt.Errorf("fetching supported currencies: %d %s", resp.StatusCode, string(body))
+	}
+
+	var codes []string
+	if err := json.NewDecoder(resp.Body).Decode(&codes); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return codes, nil
 }

--- a/internal/api/coingecko_test.go
+++ b/internal/api/coingecko_test.go
@@ -581,3 +581,123 @@ func TestNewHTTPClientDefaultMinInterval(t *testing.T) {
 		t.Errorf("expected minInterval to be 2s, got %v", client.minInterval)
 	}
 }
+
+func TestFetchSupportedCurrenciesSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := []string{"usd", "eur", "btc"}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := &HTTPClient{
+		httpClient: server.Client(),
+		baseURL:    server.URL,
+	}
+
+	codes, err := client.FetchSupportedCurrencies(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(codes) != 3 {
+		t.Fatalf("expected 3 codes, got %d", len(codes))
+	}
+
+	expected := []string{"usd", "eur", "btc"}
+	for i, exp := range expected {
+		if codes[i] != exp {
+			t.Errorf("position %d: expected %s, got %s", i, exp, codes[i])
+		}
+	}
+}
+
+func TestFetchSupportedCurrenciesWithAPIKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiKey := r.Header.Get("x-cg-demo-api-key")
+		if apiKey != "test-key" {
+			t.Errorf("expected API key 'test-key', got %s", apiKey)
+		}
+
+		response := []string{"usd"}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := &HTTPClient{
+		httpClient: server.Client(),
+		baseURL:    server.URL,
+		apiKey:     "test-key",
+	}
+
+	_, err := client.FetchSupportedCurrencies(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFetchSupportedCurrencies429(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte("rate limit exceeded"))
+	}))
+	defer server.Close()
+
+	client := newHTTPClientWithInterval("", 10*time.Millisecond, server.URL)
+
+	_, err := client.FetchSupportedCurrencies(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !IsRateLimitError(err) {
+		t.Errorf("expected IsRateLimitError to return true, got false")
+	}
+}
+
+func TestFetchSupportedCurrenciesNetworkError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("server doesn't support hijacking")
+		}
+		conn, _, err := hijacker.Hijack()
+		if err != nil {
+			t.Fatalf("failed to hijack connection: %v", err)
+		}
+		_ = conn.Close()
+	}))
+	defer server.Close()
+
+	client := &HTTPClient{
+		httpClient: server.Client(),
+		baseURL:    server.URL,
+	}
+
+	_, err := client.FetchSupportedCurrencies(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestFetchSupportedCurrenciesContextCancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	client := &HTTPClient{
+		httpClient: server.Client(),
+		baseURL:    server.URL,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.FetchSupportedCurrencies(ctx)
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+}

--- a/internal/api/fiat.go
+++ b/internal/api/fiat.go
@@ -1,0 +1,53 @@
+package api
+
+// FiatCurrencies is a hardcoded map of fiat currency codes to their display names.
+// These are filtered against the CoinGecko API response to determine which
+// currencies the app supports.
+var FiatCurrencies = map[string]string{
+	"aed": "UAE Dirham",
+	"ars": "Argentine Peso",
+	"aud": "Australian Dollar",
+	"brl": "Brazilian Real",
+	"cad": "Canadian Dollar",
+	"chf": "Swiss Franc",
+	"clp": "Chilean Peso",
+	"cny": "Chinese Yuan",
+	"czk": "Czech Koruna",
+	"dkk": "Danish Krone",
+	"eur": "Euro",
+	"gbp": "British Pound",
+	"hkd": "Hong Kong Dollar",
+	"idr": "Indonesian Rupiah",
+	"ils": "Israeli Shekel",
+	"inr": "Indian Rupee",
+	"jpy": "Japanese Yen",
+	"krw": "South Korean Won",
+	"mxn": "Mexican Peso",
+	"myr": "Malaysian Ringgit",
+	"nok": "Norwegian Krone",
+	"nzd": "New Zealand Dollar",
+	"php": "Philippine Peso",
+	"pln": "Polish Zloty",
+	"rub": "Russian Ruble",
+	"sar": "Saudi Riyal",
+	"sek": "Swedish Krona",
+	"sgd": "Singapore Dollar",
+	"thb": "Thai Baht",
+	"try": "Turkish Lira",
+	"twd": "Taiwan Dollar",
+	"usd": "US Dollar",
+	"vnd": "Vietnamese Dong",
+	"zar": "South African Rand",
+}
+
+// FilterFiat returns the intersection of apiCodes with FiatCurrencies.
+// Only codes present in both the API response and our fiat map are returned.
+func FilterFiat(apiCodes []string) []string {
+	result := make([]string, 0, len(apiCodes))
+	for _, code := range apiCodes {
+		if _, ok := FiatCurrencies[code]; ok {
+			result = append(result, code)
+		}
+	}
+	return result
+}

--- a/internal/api/fiat.go
+++ b/internal/api/fiat.go
@@ -1,5 +1,7 @@
 package api
 
+import "sort"
+
 // FiatCurrencies is a hardcoded map of fiat currency codes to their display names.
 // These are filtered against the CoinGecko API response to determine which
 // currencies the app supports.
@@ -42,6 +44,7 @@ var FiatCurrencies = map[string]string{
 
 // FilterFiat returns the intersection of apiCodes with FiatCurrencies.
 // Only codes present in both the API response and our fiat map are returned.
+// Results are sorted alphabetically by currency code.
 func FilterFiat(apiCodes []string) []string {
 	result := make([]string, 0, len(apiCodes))
 	for _, code := range apiCodes {
@@ -49,5 +52,6 @@ func FilterFiat(apiCodes []string) []string {
 			result = append(result, code)
 		}
 	}
+	sort.Strings(result)
 	return result
 }

--- a/internal/api/fiat.go
+++ b/internal/api/fiat.go
@@ -2,10 +2,10 @@ package api
 
 import "sort"
 
-// FiatCurrencies is a hardcoded map of fiat currency codes to their display names.
+// fiatCurrencies is a hardcoded map of fiat currency codes to their display names.
 // These are filtered against the CoinGecko API response to determine which
 // currencies the app supports.
-var FiatCurrencies = map[string]string{
+var fiatCurrencies = map[string]string{
 	"aed": "UAE Dirham",
 	"ars": "Argentine Peso",
 	"aud": "Australian Dollar",
@@ -42,16 +42,23 @@ var FiatCurrencies = map[string]string{
 	"zar": "South African Rand",
 }
 
-// FilterFiat returns the intersection of apiCodes with FiatCurrencies.
+// FilterFiat returns the intersection of apiCodes with fiatCurrencies.
 // Only codes present in both the API response and our fiat map are returned.
 // Results are sorted alphabetically by currency code.
 func FilterFiat(apiCodes []string) []string {
 	result := make([]string, 0, len(apiCodes))
 	for _, code := range apiCodes {
-		if _, ok := FiatCurrencies[code]; ok {
+		if _, ok := fiatCurrencies[code]; ok {
 			result = append(result, code)
 		}
 	}
 	sort.Strings(result)
 	return result
+}
+
+// FiatCurrencyName returns the display name for a fiat currency code.
+// The second return value indicates whether the code is a known fiat currency.
+func FiatCurrencyName(code string) (string, bool) {
+	name, ok := fiatCurrencies[code]
+	return name, ok
 }

--- a/internal/api/fiat_test.go
+++ b/internal/api/fiat_test.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestFilterFiatMatchesKnownCodes(t *testing.T) {
+	apiCodes := []string{"usd", "eur", "btc", "gbp", "eth"}
+	result := FilterFiat(apiCodes)
+
+	// Should contain only fiat codes: usd, eur, gbp
+	if len(result) != 3 {
+		t.Fatalf("expected 3 fiat codes, got %d: %v", len(result), result)
+	}
+
+	// Result should be in order of appearance
+	expected := []string{"usd", "eur", "gbp"}
+	for i, exp := range expected {
+		if result[i] != exp {
+			t.Errorf("position %d: expected %s, got %s", i, exp, result[i])
+		}
+	}
+}
+
+func TestFilterFiatEmptyInput(t *testing.T) {
+	result := FilterFiat([]string{})
+
+	if result == nil {
+		t.Error("expected non-nil slice, got nil")
+	}
+
+	if len(result) != 0 {
+		t.Errorf("expected empty slice, got %d items", len(result))
+	}
+}
+
+func TestFilterFiatNoMatches(t *testing.T) {
+	// All crypto codes
+	result := FilterFiat([]string{"btc", "eth", "xrp", "ada"})
+
+	if len(result) != 0 {
+		t.Errorf("expected empty result for all-crypto input, got %v", result)
+	}
+}
+
+func TestFilterFiatAllFiat(t *testing.T) {
+	// Build list of all fiat codes from the map
+	allFiat := make([]string, 0, len(FiatCurrencies))
+	for code := range FiatCurrencies {
+		allFiat = append(allFiat, code)
+	}
+
+	result := FilterFiat(allFiat)
+
+	if len(result) != len(FiatCurrencies) {
+		t.Errorf("expected %d fiat codes, got %d", len(FiatCurrencies), len(result))
+	}
+
+	// Sort both for comparison
+	sort.Strings(result)
+	sort.Strings(allFiat)
+
+	for i, exp := range allFiat {
+		if result[i] != exp {
+			t.Errorf("position %d: expected %s, got %s", i, exp, result[i])
+		}
+	}
+}

--- a/internal/api/fiat_test.go
+++ b/internal/api/fiat_test.go
@@ -46,15 +46,15 @@ func TestFilterFiatNoMatches(t *testing.T) {
 
 func TestFilterFiatAllFiat(t *testing.T) {
 	// Build list of all fiat codes from the map
-	allFiat := make([]string, 0, len(FiatCurrencies))
-	for code := range FiatCurrencies {
+	allFiat := make([]string, 0, len(fiatCurrencies))
+	for code := range fiatCurrencies {
 		allFiat = append(allFiat, code)
 	}
 
 	result := FilterFiat(allFiat)
 
-	if len(result) != len(FiatCurrencies) {
-		t.Errorf("expected %d fiat codes, got %d", len(FiatCurrencies), len(result))
+	if len(result) != len(fiatCurrencies) {
+		t.Errorf("expected %d fiat codes, got %d", len(fiatCurrencies), len(result))
 	}
 
 	// Sort both for comparison

--- a/internal/api/fiat_test.go
+++ b/internal/api/fiat_test.go
@@ -14,8 +14,8 @@ func TestFilterFiatMatchesKnownCodes(t *testing.T) {
 		t.Fatalf("expected 3 fiat codes, got %d: %v", len(result), result)
 	}
 
-	// Result should be in order of appearance
-	expected := []string{"usd", "eur", "gbp"}
+	// Result should be sorted alphabetically
+	expected := []string{"eur", "gbp", "usd"}
 	for i, exp := range expected {
 		if result[i] != exp {
 			t.Errorf("position %d: expected %s, got %s", i, exp, result[i])

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -22,3 +22,15 @@ CREATE TABLE IF NOT EXISTS holdings (
     amount       REAL    NOT NULL,
     UNIQUE(portfolio_id, coin_id)
 );
+
+CREATE TABLE IF NOT EXISTS currencies (
+    code TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT NOT NULL UNIQUE,
+    value TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO settings (key, value) VALUES ('selected_currency', 'usd');

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS holdings (
 );
 
 CREATE TABLE IF NOT EXISTS currencies (
-    code TEXT NOT NULL UNIQUE,
+    code TEXT PRIMARY KEY,
     name TEXT NOT NULL
 );
 

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -248,4 +249,83 @@ func (s *SQLiteStore) GetHoldingsForPortfolio(ctx context.Context, portfolioID i
 		return nil, fmt.Errorf("iterating holdings: %w", err)
 	}
 	return holdings, nil
+}
+
+// UpsertCurrencies inserts or updates currencies in a transaction.
+func (s *SQLiteStore) UpsertCurrencies(ctx context.Context, currencies []Currency) error {
+	if len(currencies) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO currencies (code, name) VALUES (?, ?)
+		ON CONFLICT(code) DO UPDATE SET name = excluded.name
+	`)
+	if err != nil {
+		return fmt.Errorf("preparing upsert statement: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+
+	for _, c := range currencies {
+		if _, err := stmt.ExecContext(ctx, c.Code, c.Name); err != nil {
+			return fmt.Errorf("upserting currency %s: %w", c.Code, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing transaction: %w", err)
+	}
+	return nil
+}
+
+// GetAllCurrencies returns all currencies ordered by code.
+func (s *SQLiteStore) GetAllCurrencies(ctx context.Context) ([]Currency, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT code, name FROM currencies ORDER BY code ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("querying currencies: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	currencies := make([]Currency, 0)
+	for rows.Next() {
+		var c Currency
+		if err := rows.Scan(&c.Code, &c.Name); err != nil {
+			return nil, fmt.Errorf("scanning currency: %w", err)
+		}
+		currencies = append(currencies, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating currencies: %w", err)
+	}
+	return currencies, nil
+}
+
+// GetSetting returns a setting value or empty string if not found.
+func (s *SQLiteStore) GetSetting(ctx context.Context, key string) (string, error) {
+	var value string
+	err := s.db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, key).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("getting setting %q: %w", key, err)
+	}
+	return value, nil
+}
+
+// SetSetting upserts a setting value.
+func (s *SQLiteStore) SetSetting(ctx context.Context, key, value string) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO settings (key, value) VALUES (?, ?)
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value
+	`, key, value)
+	if err != nil {
+		return fmt.Errorf("setting %q: %w", key, err)
+	}
+	return nil
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1303,3 +1303,296 @@ func TestCreatePortfolioDuplicateName(t *testing.T) {
 		t.Error("expected error when creating portfolio with duplicate name, got nil")
 	}
 }
+
+func TestUpsertCurrencies(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	s := NewSQLiteStore(database)
+	defer func() {
+		_ = s.Close()
+	}()
+
+	currencies := []Currency{
+		{Code: "eur", Name: "Euro"},
+		{Code: "usd", Name: "US Dollar"},
+		{Code: "gbp", Name: "British Pound"},
+	}
+
+	if err := s.UpsertCurrencies(ctx, currencies); err != nil {
+		t.Fatalf("failed to upsert currencies: %v", err)
+	}
+
+	result, err := s.GetAllCurrencies(ctx)
+	if err != nil {
+		t.Fatalf("failed to get all currencies: %v", err)
+	}
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 currencies, got %d", len(result))
+	}
+
+	// Should be ordered by code: eur, gbp, usd
+	expected := []struct {
+		code string
+		name string
+	}{
+		{"eur", "Euro"},
+		{"gbp", "British Pound"},
+		{"usd", "US Dollar"},
+	}
+
+	for i, exp := range expected {
+		if result[i].Code != exp.code {
+			t.Errorf("position %d: expected code %s, got %s", i, exp.code, result[i].Code)
+		}
+		if result[i].Name != exp.name {
+			t.Errorf("position %d: expected name %s, got %s", i, exp.name, result[i].Name)
+		}
+	}
+}
+
+func TestUpsertCurrenciesUpdatesName(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	s := NewSQLiteStore(database)
+	defer func() {
+		_ = s.Close()
+	}()
+
+	// Insert with original name
+	if err := s.UpsertCurrencies(ctx, []Currency{{Code: "usd", Name: "Old Name"}}); err != nil {
+		t.Fatalf("failed to upsert first time: %v", err)
+	}
+
+	// Upsert with new name
+	if err := s.UpsertCurrencies(ctx, []Currency{{Code: "usd", Name: "US Dollar"}}); err != nil {
+		t.Fatalf("failed to upsert second time: %v", err)
+	}
+
+	result, err := s.GetAllCurrencies(ctx)
+	if err != nil {
+		t.Fatalf("failed to get currencies: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 currency, got %d", len(result))
+	}
+
+	if result[0].Name != "US Dollar" {
+		t.Errorf("expected updated name 'US Dollar', got %s", result[0].Name)
+	}
+}
+
+func TestUpsertCurrenciesEmpty(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	s := NewSQLiteStore(database)
+	defer func() {
+		_ = s.Close()
+	}()
+
+	// Empty slice should be no-op without error
+	if err := s.UpsertCurrencies(ctx, []Currency{}); err != nil {
+		t.Errorf("expected no error for empty slice, got: %v", err)
+	}
+}
+
+func TestGetAllCurrenciesEmpty(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	s := NewSQLiteStore(database)
+	defer func() {
+		_ = s.Close()
+	}()
+
+	result, err := s.GetAllCurrencies(ctx)
+	if err != nil {
+		t.Fatalf("failed to get currencies: %v", err)
+	}
+
+	if result == nil {
+		t.Error("expected non-nil slice, got nil")
+	}
+
+	if len(result) != 0 {
+		t.Errorf("expected 0 currencies, got %d", len(result))
+	}
+}
+
+func TestGetSettingExisting(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	s := NewSQLiteStore(database)
+	defer func() {
+		_ = s.Close()
+	}()
+
+	// selected_currency should be seeded on DB init
+	value, err := s.GetSetting(ctx, "selected_currency")
+	if err != nil {
+		t.Fatalf("failed to get setting: %v", err)
+	}
+
+	if value != "usd" {
+		t.Errorf("expected 'usd', got %q", value)
+	}
+}
+
+func TestGetSettingMissing(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	s := NewSQLiteStore(database)
+	defer func() {
+		_ = s.Close()
+	}()
+
+	value, err := s.GetSetting(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if value != "" {
+		t.Errorf("expected empty string, got %q", value)
+	}
+}
+
+func TestSetSettingInsert(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	s := NewSQLiteStore(database)
+	defer func() {
+		_ = s.Close()
+	}()
+
+	if err := s.SetSetting(ctx, "test_key", "test_value"); err != nil {
+		t.Fatalf("failed to set setting: %v", err)
+	}
+
+	value, err := s.GetSetting(ctx, "test_key")
+	if err != nil {
+		t.Fatalf("failed to get setting: %v", err)
+	}
+
+	if value != "test_value" {
+		t.Errorf("expected 'test_value', got %q", value)
+	}
+}
+
+func TestSetSettingUpdate(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	s := NewSQLiteStore(database)
+	defer func() {
+		_ = s.Close()
+	}()
+
+	// Set initial value
+	if err := s.SetSetting(ctx, "update_test", "original"); err != nil {
+		t.Fatalf("failed to set setting: %v", err)
+	}
+
+	// Update to new value
+	if err := s.SetSetting(ctx, "update_test", "updated"); err != nil {
+		t.Fatalf("failed to update setting: %v", err)
+	}
+
+	value, err := s.GetSetting(ctx, "update_test")
+	if err != nil {
+		t.Fatalf("failed to get setting: %v", err)
+	}
+
+	if value != "updated" {
+		t.Errorf("expected 'updated', got %q", value)
+	}
+}
+
+func TestDefaultCurrencySeed(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() {
+		_ = database.Close()
+	}()
+
+	s := NewSQLiteStore(database)
+	defer func() {
+		_ = s.Close()
+	}()
+
+	// Verify default currency is seeded
+	value, err := s.GetSetting(ctx, "selected_currency")
+	if err != nil {
+		t.Fatalf("failed to get setting: %v", err)
+	}
+
+	if value != "usd" {
+		t.Errorf("expected default currency 'usd', got %q", value)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -44,6 +44,12 @@ type HoldingRow struct {
 	Proportion  float64 // Value / portfolio_total * 100, computed via window function
 }
 
+// Currency represents a fiat currency with its code and display name.
+type Currency struct {
+	Code string
+	Name string
+}
+
 // Store defines the interface for cryptocurrency data persistence.
 type Store interface {
 	UpsertCoin(ctx context.Context, c Coin) error
@@ -63,4 +69,10 @@ type Store interface {
 	// new in Slice 9
 	RenamePortfolio(ctx context.Context, id int64, name string) error
 	DeletePortfolio(ctx context.Context, id int64) error
+
+	// new in Slice 13
+	UpsertCurrencies(ctx context.Context, currencies []Currency) error
+	GetAllCurrencies(ctx context.Context) ([]Currency, error)
+	GetSetting(ctx context.Context, key string) (string, error)
+	SetSetting(ctx context.Context, key, value string) error
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -14,9 +14,10 @@ type tab int
 const (
 	tabMarkets tab = iota
 	tabPortfolio
+	tabSettings
 )
 
-const tabCount = 2
+const tabCount = 3
 
 func tabBarActiveStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
@@ -38,6 +39,7 @@ type AppModel struct {
 	activeTab tab
 	markets   MarketsModel
 	portfolio PortfolioModel
+	settings  SettingsModel
 }
 
 // NewAppModel creates a new AppModel with the given dependencies.
@@ -46,12 +48,13 @@ func NewAppModel(ctx context.Context, s store.Store, c api.CoinGeckoClient) AppM
 		activeTab: tabMarkets,
 		markets:   NewMarketsModel(ctx, s, c),
 		portfolio: NewPortfolioModel(ctx, s),
+		settings:  NewSettingsModel(ctx, s, c),
 	}
 }
 
-// Init delegates to both children models' Init commands.
+// Init delegates to all children models' Init commands.
 func (m AppModel) Init() tea.Cmd {
-	return tea.Batch(m.markets.Init(), m.portfolio.Init())
+	return tea.Batch(m.markets.Init(), m.portfolio.Init(), m.settings.Init())
 }
 
 // Update handles WindowSizeMsg (propagated to children with height-1),
@@ -65,10 +68,11 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		childMsg := tea.WindowSizeMsg{Width: msg.Width, Height: msg.Height - 1}
-		var cmd1, cmd2 tea.Cmd
+		var cmd1, cmd2, cmd3 tea.Cmd
 		m.markets, cmd1 = m.markets.update(childMsg)
 		m.portfolio, cmd2 = m.portfolio.update(childMsg)
-		return m, tea.Batch(cmd1, cmd2)
+		m.settings, cmd3 = m.settings.update(childMsg)
+		return m, tea.Batch(cmd1, cmd2, cmd3)
 
 	case tea.KeyMsg:
 		if msg.Type == tea.KeyCtrlC {
@@ -93,22 +97,26 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					case '2':
 						m.activeTab = tabPortfolio
 						return m, nil
+					case '3':
+						m.activeTab = tabSettings
+						return m, nil
 					}
 				}
 			}
 		}
 	}
 
-	// Background messages (non-key, non-resize) are always forwarded to both
+	// Background messages (non-key, non-resize) are always forwarded to all
 	// children via tea.Batch. This ensures that async responses like
 	// coinsLoadedMsg and pricesUpdatedMsg reach whichever tab issued the
 	// command, even if the user has since switched tabs. Without this
 	// broadcast, responses would be silently dropped when the inactive tab
 	// doesn't match the issuing tab.
-	var cmd1, cmd2 tea.Cmd
+	var cmd1, cmd2, cmd3 tea.Cmd
 	m.markets, cmd1 = m.markets.update(msg)
 	m.portfolio, cmd2 = m.portfolio.update(msg)
-	return m, tea.Batch(cmd1, cmd2)
+	m.settings, cmd3 = m.settings.update(msg)
+	return m, tea.Batch(cmd1, cmd2, cmd3)
 }
 
 // View renders the tab bar + active child view.
@@ -119,27 +127,36 @@ func (m AppModel) View() string {
 		return tabBar + "\n" + m.markets.View()
 	case tabPortfolio:
 		return tabBar + "\n" + m.portfolio.View()
+	case tabSettings:
+		return tabBar + "\n" + m.settings.View()
 	}
 	return tabBar
 }
 
-// renderTabBar renders "[ Markets ]  [ Portfolio ]" with active tab highlighted.
+// renderTabBar renders "[ Markets ]  [ Portfolio ]  [ Settings ]" with active tab highlighted.
 func (m AppModel) renderTabBar() string {
 	inactiveStyle := tabBarInactiveStyle()
 	activeStyle := tabBarActiveStyle()
 
 	marketsLabel := " Markets "
 	portfolioLabel := " Portfolio "
+	settingsLabel := " Settings "
 
 	if m.activeTab == tabMarkets {
 		marketsLabel = activeStyle.Render(marketsLabel)
 		portfolioLabel = inactiveStyle.Render(portfolioLabel)
-	} else {
+		settingsLabel = inactiveStyle.Render(settingsLabel)
+	} else if m.activeTab == tabPortfolio {
 		marketsLabel = inactiveStyle.Render(marketsLabel)
 		portfolioLabel = activeStyle.Render(portfolioLabel)
+		settingsLabel = inactiveStyle.Render(settingsLabel)
+	} else {
+		marketsLabel = inactiveStyle.Render(marketsLabel)
+		portfolioLabel = inactiveStyle.Render(portfolioLabel)
+		settingsLabel = activeStyle.Render(settingsLabel)
 	}
 
-	return marketsLabel + "  " + portfolioLabel
+	return marketsLabel + "  " + portfolioLabel + "  " + settingsLabel
 }
 
 // activeInputActive returns whether the currently active child has a text input focused.
@@ -149,6 +166,8 @@ func (m AppModel) activeInputActive() bool {
 		return m.markets.InputActive()
 	case tabPortfolio:
 		return m.portfolio.InputActive()
+	case tabSettings:
+		return m.settings.InputActive()
 	}
 	return false
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -142,15 +142,16 @@ func (m AppModel) renderTabBar() string {
 	portfolioLabel := " Portfolio "
 	settingsLabel := " Settings "
 
-	if m.activeTab == tabMarkets {
+	switch m.activeTab {
+	case tabMarkets:
 		marketsLabel = activeStyle.Render(marketsLabel)
 		portfolioLabel = inactiveStyle.Render(portfolioLabel)
 		settingsLabel = inactiveStyle.Render(settingsLabel)
-	} else if m.activeTab == tabPortfolio {
+	case tabPortfolio:
 		marketsLabel = inactiveStyle.Render(marketsLabel)
 		portfolioLabel = activeStyle.Render(portfolioLabel)
 		settingsLabel = inactiveStyle.Render(settingsLabel)
-	} else {
+	case tabSettings:
 		marketsLabel = inactiveStyle.Render(marketsLabel)
 		portfolioLabel = inactiveStyle.Render(portfolioLabel)
 		settingsLabel = activeStyle.Render(settingsLabel)

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -104,7 +104,7 @@ func TestTabKeyWrapsToMarkets(t *testing.T) {
 	stub := &StubStore{}
 	api := &StubAPI{}
 	m := NewAppModel(context.Background(), stub, api)
-	m.activeTab = tabPortfolio
+	m.activeTab = tabSettings
 	m.width = 100
 	m.height = 30
 
@@ -146,8 +146,8 @@ func TestShiftTabWrapsToPortfolio(t *testing.T) {
 	updated, _ := m.Update(msg)
 	model := updated.(AppModel)
 
-	if model.activeTab != tabPortfolio {
-		t.Errorf("expected Shift+Tab to wrap to Portfolio (%d), got %d", tabPortfolio, model.activeTab)
+	if model.activeTab != tabSettings {
+		t.Errorf("expected Shift+Tab to wrap to Settings (%d), got %d", tabSettings, model.activeTab)
 	}
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -348,3 +348,132 @@ func TestPanelTitlesDisplayed(t *testing.T) {
 		t.Errorf("expected view to contain 'Holdings' title, got %q", view)
 	}
 }
+
+func TestThreeKeySelectsSettings(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.width = 100
+	m.height = 30
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	updated, _ := m.Update(msg)
+	model := updated.(AppModel)
+
+	if model.activeTab != tabSettings {
+		t.Errorf("expected '3' to select Settings (%d), got %d", tabSettings, model.activeTab)
+	}
+}
+
+func TestTabBarShowsSettings(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.width = 100
+	m.height = 30
+
+	view := m.View()
+	if !strings.Contains(view, "Settings") {
+		t.Errorf("expected view to contain 'Settings', got %q", view)
+	}
+}
+
+func TestSettingsInputActiveSuppressesTabSwitch(t *testing.T) {
+	currencies := []store.Currency{
+		{Code: "usd", Name: "US Dollar"},
+	}
+	stub := &StubStore{currencies: currencies}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.activeTab = tabSettings
+	m.width = 100
+	m.height = 30
+
+	// Load currencies into settings
+	m.settings.currencies = currencies
+
+	// Open picker (Enter key)
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	updated, _ := m.Update(msg)
+	m = updated.(AppModel)
+
+	// Verify we're in picking mode
+	if !m.settings.InputActive() {
+		t.Fatal("expected settings picker to be active")
+	}
+
+	// Try to switch tabs with Tab - should be suppressed
+	msg = tea.KeyMsg{Type: tea.KeyTab}
+	updated, _ = m.Update(msg)
+	model := updated.(AppModel)
+
+	if model.activeTab != tabSettings {
+		t.Errorf("expected Tab to be suppressed when picker active, got tab %d", model.activeTab)
+	}
+}
+
+func TestTabCyclesThroughAllThreeTabs(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.width = 100
+	m.height = 30
+
+	// Tab from Markets -> Portfolio
+	m.activeTab = tabMarkets
+	msg := tea.KeyMsg{Type: tea.KeyTab}
+	updated, _ := m.Update(msg)
+	m = updated.(AppModel)
+	if m.activeTab != tabPortfolio {
+		t.Errorf("expected Tab to go Markets -> Portfolio, got %d", m.activeTab)
+	}
+
+	// Tab from Portfolio -> Settings
+	msg = tea.KeyMsg{Type: tea.KeyTab}
+	updated, _ = m.Update(msg)
+	m = updated.(AppModel)
+	if m.activeTab != tabSettings {
+		t.Errorf("expected Tab to go Portfolio -> Settings, got %d", m.activeTab)
+	}
+
+	// Tab from Settings -> Markets (wrap)
+	msg = tea.KeyMsg{Type: tea.KeyTab}
+	updated, _ = m.Update(msg)
+	m = updated.(AppModel)
+	if m.activeTab != tabMarkets {
+		t.Errorf("expected Tab to go Settings -> Markets (wrap), got %d", m.activeTab)
+	}
+}
+
+func TestShiftTabCyclesBackwards(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.width = 100
+	m.height = 30
+
+	// Shift+Tab from Markets -> Settings (wrap backwards)
+	m.activeTab = tabMarkets
+	msg := tea.KeyMsg{Type: tea.KeyShiftTab}
+	updated, _ := m.Update(msg)
+	m = updated.(AppModel)
+	if m.activeTab != tabSettings {
+		t.Errorf("expected Shift+Tab to go Markets -> Settings (wrap), got %d", m.activeTab)
+	}
+
+	// Shift+Tab from Settings -> Portfolio
+	msg = tea.KeyMsg{Type: tea.KeyShiftTab}
+	updated, _ = m.Update(msg)
+	m = updated.(AppModel)
+	if m.activeTab != tabPortfolio {
+		t.Errorf("expected Shift+Tab to go Settings -> Portfolio, got %d", m.activeTab)
+	}
+
+	// Shift+Tab from Portfolio -> Markets
+	msg = tea.KeyMsg{Type: tea.KeyShiftTab}
+	updated, _ = m.Update(msg)
+	m = updated.(AppModel)
+	if m.activeTab != tabMarkets {
+		t.Errorf("expected Shift+Tab to go Portfolio -> Markets, got %d", m.activeTab)
+	}
+}

--- a/internal/ui/markets.go
+++ b/internal/ui/markets.go
@@ -310,36 +310,24 @@ func (m MarketsModel) statusRight() string {
 // renderStatusBar returns a two-sided status bar with hints on the left and
 // sync status on the right.
 func (m MarketsModel) renderStatusBar() string {
-	leftContent := "j/k navigate • g/G top/bottom • r refresh • q quit"
-	rightContent := m.statusRight()
+	left := "j/k navigate • g/G top/bottom • r refresh • q quit"
+	return renderStatusBar(m.width, left, m.styledStatusRight())
+}
 
-	grayStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#888888"))
-	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF4444"))
-	greenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00"))
-	yellowStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFD700"))
-
-	rateLimitStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF8C00")) // dark orange
-
-	var rightStyled string
+func (m MarketsModel) styledStatusRight() string {
+	right := m.statusRight()
 	switch {
-	case strings.HasPrefix(rightContent, "Rate limited"):
-		rightStyled = rateLimitStyle.Render(rightContent)
-	case rightContent == "Synced":
-		rightStyled = greenStyle.Render(rightContent)
-	case rightContent == "Stale":
-		rightStyled = yellowStyle.Render(rightContent)
-	case strings.HasPrefix(rightContent, "error:"):
-		rightStyled = errStyle.Render(rightContent)
+	case strings.HasPrefix(right, "Rate limited"):
+		return statusBarOrange.Render(right)
+	case right == "Synced":
+		return statusBarGreen.Render(right)
+	case right == "Stale":
+		return statusBarYellow.Render(right)
+	case strings.HasPrefix(right, "error:"):
+		return statusBarRed.Render(right)
 	default:
-		rightStyled = grayStyle.Render(rightContent)
+		return statusBarGray.Render(right)
 	}
-
-	leftStyled := grayStyle.Render(leftContent)
-	padding := m.width - lipgloss.Width(leftContent) - lipgloss.Width(rightContent)
-	if padding < 1 {
-		padding = 1
-	}
-	return leftStyled + strings.Repeat(" ", padding) + rightStyled
 }
 
 // moveCursor moves the cursor by delta and adjusts the viewport.

--- a/internal/ui/portfolio.go
+++ b/internal/ui/portfolio.go
@@ -851,34 +851,34 @@ func (m PortfolioModel) renderRightPanel(height, width int) string {
 }
 
 func (m PortfolioModel) renderStatusBar() string {
-	var content string
+	var hints string
 	switch m.mode.(type) {
 	case browsing:
-		content = "j/k portfolios • Enter list • e edit • X delete • PgUp/PgDn scroll • n new • q quit"
+		hints = "j/k portfolios • Enter list • e edit • X delete • PgUp/PgDn scroll • n new • q quit"
 	case creating:
-		content = "Enter to create • Esc to cancel"
+		hints = "Enter to create • Esc to cancel"
 	case addCoin:
-		content = "j/k navigate • type to filter • Enter select • Esc cancel"
+		hints = "j/k navigate • type to filter • Enter select • Esc cancel"
 	case addAmount:
-		content = "Enter to confirm • Esc back to coin selection"
+		hints = "Enter to confirm • Esc back to coin selection"
 	case listing:
-		content = "j/k holdings • g/G top/bottom • Enter edit • X delete • a add holding • Esc back to menu • q quit"
+		hints = "j/k holdings • g/G top/bottom • Enter edit • X delete • a add holding • Esc back to menu • q quit"
 	case editingAmount:
-		content = "Enter to save • Esc cancel"
+		hints = "Enter to save • Esc cancel"
 	case deleting:
-		content = "Enter to confirm delete • Esc cancel"
+		hints = "Enter to confirm delete • Esc cancel"
 	case editingPortfolio:
-		content = "Enter to save • Esc to cancel"
+		hints = "Enter to save • Esc to cancel"
 	case deletingPortfolio:
-		content = "Enter to delete • Esc to cancel"
+		hints = "Enter to delete • Esc to cancel"
 	}
 
+	var right string
 	if m.lastErr != "" {
-		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
-		content += " • " + errStyle.Render("error: "+m.lastErr)
+		right = statusBarRed.Render("error: " + m.lastErr)
 	}
 
-	return content
+	return renderStatusBar(m.width, hints, right)
 }
 
 func (m PortfolioModel) openEditPortfolioDialog() PortfolioModel {

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -1,0 +1,315 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/fredericomozzato/crypto_tracker/internal/api"
+	"github.com/fredericomozzato/crypto_tracker/internal/store"
+)
+
+// settingsMode is a discriminated union for SettingsModel states.
+type settingsMode interface{ isSettingsMode() }
+
+type settingsBrowsing struct{}
+type settingsPicking struct {
+	filter   textinput.Model
+	all      []store.Currency
+	filtered []store.Currency
+	cursor   int
+}
+
+func (settingsBrowsing) isSettingsMode() {}
+func (settingsPicking) isSettingsMode()  {}
+
+// SettingsModel manages the Settings tab UI.
+type SettingsModel struct {
+	ctx          context.Context
+	store        store.Store
+	client       api.CoinGeckoClient
+	width        int
+	height       int
+	mode         settingsMode
+	selectedCode string
+	currencies   []store.Currency
+	loading      bool
+	lastErr      string
+}
+
+// Message types for SettingsModel.
+type settingsLoadedMsg struct {
+	currencies []store.Currency
+	selected   string
+}
+
+type settingsNeedFetchMsg struct{}
+
+type currenciesFetchedMsg struct {
+	codes []string
+}
+
+type currenciesUpsertedMsg struct {
+	currencies []store.Currency
+}
+
+// NewSettingsModel creates a new SettingsModel with the given dependencies.
+func NewSettingsModel(ctx context.Context, s store.Store, c api.CoinGeckoClient) SettingsModel {
+	return SettingsModel{
+		ctx:          ctx,
+		store:        s,
+		client:       c,
+		mode:         settingsBrowsing{},
+		selectedCode: "usd",
+	}
+}
+
+// Init returns the initial command to load settings data.
+func (m SettingsModel) Init() tea.Cmd {
+	return cmdLoadSettings(m.store)
+}
+
+// update is the internal update function that handles messages.
+func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+
+	case settingsLoadedMsg:
+		m.currencies = msg.currencies
+		if msg.selected != "" {
+			m.selectedCode = msg.selected
+		}
+
+	case settingsNeedFetchMsg:
+		m.loading = true
+		return m, cmdFetchCurrencies(m.client)
+
+	case currenciesFetchedMsg:
+		// Filter API codes against fiat map
+		fiatCodes := api.FilterFiat(msg.codes)
+		currencies := make([]store.Currency, len(fiatCodes))
+		for i, code := range fiatCodes {
+			currencies[i] = store.Currency{
+				Code: code,
+				Name: api.FiatCurrencies[code],
+			}
+		}
+		return m, cmdUpsertCurrencies(m.store, currencies)
+
+	case currenciesUpsertedMsg:
+		m.currencies = msg.currencies
+		m.loading = false
+		// Transition to picking mode
+		m.mode = m.makePickingMode(msg.currencies)
+
+	case tea.KeyMsg:
+		switch m.mode.(type) {
+		case settingsBrowsing:
+			switch msg.Type {
+			case tea.KeyEnter:
+				if len(m.currencies) == 0 {
+					return m, func() tea.Msg { return settingsNeedFetchMsg{} }
+				}
+				m.mode = m.makePickingMode(m.currencies)
+			}
+
+		case settingsPicking:
+			picking := m.mode.(settingsPicking)
+
+			switch msg.Type {
+			case tea.KeyEscape:
+				m.mode = settingsBrowsing{}
+				return m, nil
+
+			case tea.KeyEnter:
+				// No-op for Slice 13 - selection handled in Slice 14
+				return m, nil
+
+			case tea.KeyRunes:
+				for _, r := range msg.Runes {
+					switch r {
+					case 'j', 'J':
+						if picking.cursor < len(picking.filtered)-1 {
+							picking.cursor++
+						}
+						m.mode = picking
+						return m, nil
+					case 'k', 'K':
+						if picking.cursor > 0 {
+							picking.cursor--
+						}
+						m.mode = picking
+						return m, nil
+					}
+				}
+				// Forward to filter input
+				var cmd tea.Cmd
+				picking.filter, cmd = picking.filter.Update(msg)
+				picking.filtered = filterCurrencies(picking.all, picking.filter.Value())
+				// Clamp cursor
+				if picking.cursor >= len(picking.filtered) && len(picking.filtered) > 0 {
+					picking.cursor = len(picking.filtered) - 1
+				}
+				m.mode = picking
+				return m, cmd
+			}
+		}
+	}
+
+	return m, nil
+}
+
+// makePickingMode creates a picking mode with initialized filter input.
+func (m SettingsModel) makePickingMode(currencies []store.Currency) settingsPicking {
+	filter := textinput.New()
+	filter.Placeholder = "Search currencies..."
+	filter.Focus()
+
+	return settingsPicking{
+		filter:   filter,
+		all:      currencies,
+		filtered: currencies,
+		cursor:   0,
+	}
+}
+
+// filterCurrencies returns currencies matching the filter string.
+func filterCurrencies(currencies []store.Currency, filter string) []store.Currency {
+	if filter == "" {
+		return currencies
+	}
+	filter = strings.ToLower(filter)
+	result := make([]store.Currency, 0)
+	for _, c := range currencies {
+		if strings.Contains(strings.ToLower(c.Code), filter) ||
+			strings.Contains(strings.ToLower(c.Name), filter) {
+			result = append(result, c)
+		}
+	}
+	return result
+}
+
+// View renders the Settings tab content.
+func (m SettingsModel) View() string {
+	switch mode := m.mode.(type) {
+	case settingsBrowsing:
+		return m.viewBrowsing()
+	case settingsPicking:
+		return m.viewPicking(mode)
+	default:
+		return m.viewBrowsing()
+	}
+}
+
+func (m SettingsModel) viewBrowsing() string {
+	if m.loading {
+		return "Loading currencies…"
+	}
+
+	var b strings.Builder
+
+	// Show current currency
+	currencyName := m.selectedCode
+	if name, ok := api.FiatCurrencies[m.selectedCode]; ok {
+		currencyName = name
+	}
+	b.WriteString(fmt.Sprintf("Base Currency: %s (%s)\n", strings.ToUpper(m.selectedCode), currencyName))
+	b.WriteString("\n")
+	b.WriteString("Press Enter to change currency\n")
+	b.WriteString("Press Tab to switch tabs, q to quit\n")
+
+	if m.lastErr != "" {
+		b.WriteString("\n")
+		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
+		b.WriteString(errStyle.Render("Error: " + m.lastErr))
+	}
+
+	return b.String()
+}
+
+func (m SettingsModel) viewPicking(picking settingsPicking) string {
+	var b strings.Builder
+
+	// Header
+	b.WriteString("Select Base Currency\n")
+	b.WriteString("\n")
+
+	// Filter input
+	b.WriteString(picking.filter.View())
+	b.WriteString("\n\n")
+
+	// Currency list
+	if len(picking.filtered) == 0 {
+		b.WriteString("No currencies match your search.\n")
+	} else {
+		for i, c := range picking.filtered {
+			line := fmt.Sprintf("  %s - %s", strings.ToUpper(c.Code), c.Name)
+			if i == picking.cursor {
+				// Highlight selected
+				selectedStyle := lipgloss.NewStyle().
+					Background(lipgloss.Color("#4A4A4A")).
+					Foreground(lipgloss.Color("#FFFFFF"))
+				line = selectedStyle.Render("> " + line[2:])
+			}
+			b.WriteString(line + "\n")
+		}
+	}
+
+	b.WriteString("\n")
+	b.WriteString("j/k to navigate, type to filter, Enter to select (disabled), Esc to cancel\n")
+
+	return b.String()
+}
+
+// InputActive returns true when the currency picker is open.
+func (m SettingsModel) InputActive() bool {
+	_, ok := m.mode.(settingsPicking)
+	return ok
+}
+
+// cmdLoadSettings creates a command to load settings from the database.
+func cmdLoadSettings(s store.Store) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		currencies, err := s.GetAllCurrencies(ctx)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		selected, err := s.GetSetting(ctx, "selected_currency")
+		if err != nil {
+			return errMsg{err: err}
+		}
+		return settingsLoadedMsg{
+			currencies: currencies,
+			selected:   selected,
+		}
+	}
+}
+
+// cmdFetchCurrencies creates a command to fetch supported currencies from the API.
+func cmdFetchCurrencies(client api.CoinGeckoClient) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		codes, err := client.FetchSupportedCurrencies(ctx)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		return currenciesFetchedMsg{codes: codes}
+	}
+}
+
+// cmdUpsertCurrencies creates a command to persist currencies to the database.
+func cmdUpsertCurrencies(s store.Store, currencies []store.Currency) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		if err := s.UpsertCurrencies(ctx, currencies); err != nil {
+			return errMsg{err: err}
+		}
+		return currenciesUpsertedMsg{currencies: currencies}
+	}
+}

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -286,10 +286,15 @@ func (m SettingsModel) viewBrowsing() string {
 		b.WriteString(errStyle.Render("Error: " + m.lastErr))
 	}
 
-	// Pad to fill available height minus status bar
-	contentHeight := m.height - 2 // Account for borders
+	// Calculate panel inner height: total height minus borders (2) minus status bar (1)
+	innerHeight := m.height - 3
+	if innerHeight < 1 {
+		innerHeight = 1
+	}
+
+	// Pad content to fill inner height
 	lines := strings.Split(b.String(), "\n")
-	for len(lines) < contentHeight {
+	for len(lines) < innerHeight {
 		lines = append(lines, "")
 	}
 	content := strings.Join(lines, "\n")
@@ -298,7 +303,7 @@ func (m SettingsModel) viewBrowsing() string {
 	accentColor := lipgloss.Color("#00FFFF")
 	panelStyle := lipgloss.NewStyle().
 		Width(m.width - 2).
-		Height(contentHeight).
+		Height(innerHeight).
 		Border(lipgloss.NormalBorder()).
 		BorderForeground(accentColor)
 

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -286,13 +286,19 @@ func (m SettingsModel) viewBrowsing() string {
 		b.WriteString(errStyle.Render("Error: " + m.lastErr))
 	}
 
-	content := b.String()
+	// Pad to fill available height minus status bar
+	contentHeight := m.height - 2 // Account for borders
+	lines := strings.Split(b.String(), "\n")
+	for len(lines) < contentHeight {
+		lines = append(lines, "")
+	}
+	content := strings.Join(lines, "\n")
 
 	// Render with panel border for visual framing
 	accentColor := lipgloss.Color("#00FFFF")
 	panelStyle := lipgloss.NewStyle().
 		Width(m.width - 2).
-		Height(m.height - 2).
+		Height(contentHeight).
 		Border(lipgloss.NormalBorder()).
 		BorderForeground(accentColor)
 
@@ -345,7 +351,12 @@ func (m SettingsModel) viewPicking(picking settingsPicking) string {
 		Padding(1, 2).
 		Render(b.String())
 
-	content := lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, dialog)
+	// Reserve 1 line for tab bar (already subtracted in AppModel) and 1 for status bar
+	placeHeight := m.height - 1
+	if placeHeight < 1 {
+		placeHeight = 1
+	}
+	content := lipgloss.Place(m.width, placeHeight, lipgloss.Center, lipgloss.Center, dialog)
 	return content + "\n" + m.renderStatusBar()
 }
 

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -110,6 +110,10 @@ func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 		// Transition to picking mode
 		m.mode = m.makePickingMode(msg.currencies)
 
+	case errMsg:
+		m.loading = false
+		m.lastErr = msg.err.Error()
+
 	case tea.KeyMsg:
 		switch mode := m.mode.(type) {
 		case settingsBrowsing:
@@ -154,25 +158,7 @@ func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 				return m, nil
 
 			case tea.KeyRunes:
-				for _, r := range msg.Runes {
-					switch r {
-					case 'j', 'J':
-						if picking.cursor < len(picking.filtered)-1 {
-							picking.cursor++
-						}
-						picking.adjustViewport(m.height)
-						m.mode = picking
-						return m, nil
-					case 'k', 'K':
-						if picking.cursor > 0 {
-							picking.cursor--
-						}
-						picking.adjustViewport(m.height)
-						m.mode = picking
-						return m, nil
-					}
-				}
-				// Forward to filter input
+				// Forward all character keys to filter input (no j/k navigation)
 				var cmd tea.Cmd
 				picking.filter, cmd = picking.filter.Update(msg)
 				picking.filtered = filterCurrencies(picking.all, picking.filter.Value())
@@ -205,6 +191,7 @@ func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 func (m SettingsModel) makePickingMode(currencies []store.Currency) settingsPicking {
 	filter := textinput.New()
 	filter.Placeholder = "Search currencies..."
+	filter.Prompt = "" // Remove the default "> " prompt
 	filter.Focus()
 
 	return settingsPicking{
@@ -233,9 +220,9 @@ func filterCurrencies(currencies []store.Currency, filter string) []store.Curren
 }
 
 // adjustViewport updates offset so the cursor stays visible.
-// Reserves 4 lines for header, filter input, and status bar.
+// Reserves 8 lines for header, filter input, dialog borders, and status bar.
 func (p *settingsPicking) adjustViewport(height int) {
-	visibleRows := height - 4
+	visibleRows := height - 8
 	if visibleRows < 1 {
 		visibleRows = 1
 	}
@@ -276,12 +263,22 @@ func (m SettingsModel) viewBrowsing() string {
 
 	var b strings.Builder
 
-	// Show current currency
+	// Panel title
+	titleStyle := lipgloss.NewStyle().Bold(true)
+	b.WriteString(titleStyle.Render("Settings") + "\n")
+
+	// Show current currency as a selectable row
 	currencyName := m.selectedCode
 	if name, ok := api.FiatCurrencies[m.selectedCode]; ok {
 		currencyName = name
 	}
-	_, _ = fmt.Fprintf(&b, "Base Currency: %s (%s)\n", strings.ToUpper(m.selectedCode), currencyName)
+	line := fmt.Sprintf("  Base Currency: %s (%s)", strings.ToUpper(m.selectedCode), currencyName)
+
+	// Highlight the row (cursor is always on this single row in browsing mode)
+	highlight := lipgloss.NewStyle().Reverse(true)
+	line = highlight.Render(line)
+
+	b.WriteString(line + "\n")
 
 	if m.lastErr != "" {
 		b.WriteString("\n")
@@ -329,13 +326,15 @@ func (m SettingsModel) viewPicking(picking settingsPicking) string {
 
 		for i := picking.offset; i < end; i++ {
 			c := picking.filtered[i]
-			line := fmt.Sprintf("  %s - %s", strings.ToUpper(c.Code), c.Name)
+			var line string
 			if i == picking.cursor {
 				// Highlight selected
 				selectedStyle := lipgloss.NewStyle().
 					Background(lipgloss.Color("#4A4A4A")).
 					Foreground(lipgloss.Color("#FFFFFF"))
-				line = selectedStyle.Render("> " + line[2:])
+				line = selectedStyle.Render(fmt.Sprintf("> %s - %s", strings.ToUpper(c.Code), c.Name))
+			} else {
+				line = fmt.Sprintf("  %s - %s", strings.ToUpper(c.Code), c.Name)
 			}
 			b.WriteString(line + "\n")
 		}
@@ -357,7 +356,7 @@ func (m SettingsModel) renderStatusBar() string {
 	case settingsBrowsing:
 		content = "Enter to change • Tab/1-3 switch tabs • Esc back to tabs • q quit"
 	case settingsPicking:
-		content = "j/k/↑/↓ navigate • type to filter • Esc cancel"
+		content = "↑/↓ navigate • type to filter • Esc cancel"
 	}
 
 	if m.lastErr != "" {

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -220,11 +220,12 @@ func filterCurrencies(currencies []store.Currency, filter string) []store.Curren
 }
 
 // adjustViewport updates offset so the cursor stays visible.
-// Reserves 8 lines for header, filter input, dialog borders, and status bar.
-func (p *settingsPicking) adjustViewport(height int) {
-	visibleRows := height - 8
-	if visibleRows < 1 {
-		visibleRows = 1
+// The picker displays at most maxVisibleItems (10) currencies at once.
+func (p *settingsPicking) adjustViewport(_ int) {
+	const maxVisibleItems = 10
+	visibleRows := maxVisibleItems
+	if visibleRows > len(p.filtered) {
+		visibleRows = len(p.filtered)
 	}
 	if p.cursor < p.offset {
 		p.offset = p.cursor
@@ -321,14 +322,14 @@ func (m SettingsModel) viewPicking(picking settingsPicking) string {
 	b.WriteString(picking.filter.View())
 	b.WriteString("\n\n")
 
-	// Currency list with viewport
+	// Currency list - show at most 10 items to keep dialog compact
+	const maxVisibleItems = 10
 	if len(picking.filtered) == 0 {
 		b.WriteString("No currencies match your search.\n")
 	} else {
-		// Calculate visible range
-		visibleRows := m.height - 8 // Reserve space for header, filter, borders, status
-		if visibleRows < 1 {
-			visibleRows = 1
+		visibleRows := maxVisibleItems
+		if visibleRows > len(picking.filtered) {
+			visibleRows = len(picking.filtered)
 		}
 		end := picking.offset + visibleRows
 		if end > len(picking.filtered) {
@@ -356,12 +357,9 @@ func (m SettingsModel) viewPicking(picking settingsPicking) string {
 		Padding(1, 2).
 		Render(b.String())
 
-	// Reserve 1 line for tab bar (already subtracted in AppModel) and 1 for status bar
-	placeHeight := m.height - 1
-	if placeHeight < 1 {
-		placeHeight = 1
-	}
-	content := lipgloss.Place(m.width, placeHeight, lipgloss.Center, lipgloss.Center, dialog)
+	// Place dialog in center without pushing tab bar off-screen
+	// The dialog height is fixed based on content, not terminal height
+	content := lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, dialog)
 	return content + "\n" + m.renderStatusBar()
 }
 

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -15,13 +15,15 @@ import (
 // settingsMode is a discriminated union for SettingsModel states.
 type settingsMode interface{ isSettingsMode() }
 
-type settingsBrowsing struct{}
-type settingsPicking struct {
-	filter   textinput.Model
-	all      []store.Currency
-	filtered []store.Currency
-	cursor   int
-}
+type (
+	settingsBrowsing struct{}
+	settingsPicking  struct {
+		filter   textinput.Model
+		all      []store.Currency
+		filtered []store.Currency
+		cursor   int
+	}
+)
 
 func (settingsBrowsing) isSettingsMode() {}
 func (settingsPicking) isSettingsMode()  {}
@@ -108,10 +110,9 @@ func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 		m.mode = m.makePickingMode(msg.currencies)
 
 	case tea.KeyMsg:
-		switch m.mode.(type) {
+		switch mode := m.mode.(type) {
 		case settingsBrowsing:
-			switch msg.Type {
-			case tea.KeyEnter:
+			if msg.Type == tea.KeyEnter {
 				if len(m.currencies) == 0 {
 					return m, func() tea.Msg { return settingsNeedFetchMsg{} }
 				}
@@ -119,7 +120,7 @@ func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 			}
 
 		case settingsPicking:
-			picking := m.mode.(settingsPicking)
+			picking := mode
 
 			switch msg.Type {
 			case tea.KeyEscape:
@@ -218,7 +219,7 @@ func (m SettingsModel) viewBrowsing() string {
 	if name, ok := api.FiatCurrencies[m.selectedCode]; ok {
 		currencyName = name
 	}
-	b.WriteString(fmt.Sprintf("Base Currency: %s (%s)\n", strings.ToUpper(m.selectedCode), currencyName))
+	_, _ = fmt.Fprintf(&b, "Base Currency: %s (%s)\n", strings.ToUpper(m.selectedCode), currencyName)
 	b.WriteString("\n")
 	b.WriteString("Press Enter to change currency\n")
 	b.WriteString("Press Tab to switch tabs, q to quit\n")

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -97,9 +97,10 @@ func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 		fiatCodes := api.FilterFiat(msg.codes)
 		currencies := make([]store.Currency, len(fiatCodes))
 		for i, code := range fiatCodes {
+			name, _ := api.FiatCurrencyName(code)
 			currencies[i] = store.Currency{
 				Code: code,
-				Name: api.FiatCurrencies[code],
+				Name: name,
 			}
 		}
 		return m, m.cmdUpsertCurrencies(currencies)
@@ -124,8 +125,7 @@ func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 				}
 				m.mode = m.makePickingMode(m.currencies)
 			case tea.KeyEscape:
-				// Return focus to tab bar - this is handled by AppModel
-				// The tab itself doesn't need to do anything special
+				// Esc does nothing in browsing mode (user can use Tab/1-3 to switch tabs)
 				return m, nil
 			}
 
@@ -145,7 +145,7 @@ func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 				if picking.cursor < len(picking.filtered)-1 {
 					picking.cursor++
 				}
-				picking.adjustViewport(m.height)
+				picking.adjustViewport()
 				m.mode = picking
 				return m, nil
 
@@ -153,7 +153,7 @@ func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 				if picking.cursor > 0 {
 					picking.cursor--
 				}
-				picking.adjustViewport(m.height)
+				picking.adjustViewport()
 				m.mode = picking
 				return m, nil
 
@@ -221,7 +221,7 @@ func filterCurrencies(currencies []store.Currency, filter string) []store.Curren
 
 // adjustViewport updates offset so the cursor stays visible.
 // The picker displays at most maxVisibleItems (10) currencies at once.
-func (p *settingsPicking) adjustViewport(_ int) {
+func (p *settingsPicking) adjustViewport() {
 	const maxVisibleItems = 10
 	visibleRows := maxVisibleItems
 	if visibleRows > len(p.filtered) {
@@ -270,7 +270,7 @@ func (m SettingsModel) viewBrowsing() string {
 
 	// Show current currency as a selectable row
 	currencyName := m.selectedCode
-	if name, ok := api.FiatCurrencies[m.selectedCode]; ok {
+	if name, ok := api.FiatCurrencyName(m.selectedCode); ok {
 		currencyName = name
 	}
 	line := fmt.Sprintf("  Base Currency: %s (%s)", strings.ToUpper(m.selectedCode), currencyName)
@@ -280,12 +280,6 @@ func (m SettingsModel) viewBrowsing() string {
 	line = highlight.Render(line)
 
 	b.WriteString(line + "\n")
-
-	if m.lastErr != "" {
-		b.WriteString("\n")
-		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
-		b.WriteString(errStyle.Render("Error: " + m.lastErr))
-	}
 
 	// Calculate panel inner height: total height minus borders (2) minus status bar (1)
 	innerHeight := m.height - 3
@@ -358,8 +352,8 @@ func (m SettingsModel) viewPicking(picking settingsPicking) string {
 		Render(b.String())
 
 	// Place dialog in center without pushing tab bar off-screen
-	// The dialog height is fixed based on content, not terminal height
-	content := lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, dialog)
+	// Leave one row for the status bar to prevent overflow
+	content := lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, dialog)
 	return content + "\n" + m.renderStatusBar()
 }
 
@@ -368,7 +362,7 @@ func (m SettingsModel) renderStatusBar() string {
 	var content string
 	switch m.mode.(type) {
 	case settingsBrowsing:
-		content = "Enter to change • Tab/1-3 switch tabs • Esc back to tabs • q quit"
+		content = "Enter to change • Tab/1-3 switch tabs • q quit"
 	case settingsPicking:
 		content = "↑/↓ navigate • type to filter • Esc cancel"
 	}

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -359,20 +359,20 @@ func (m SettingsModel) viewPicking(picking settingsPicking) string {
 
 // renderStatusBar returns a status bar with keyboard hints.
 func (m SettingsModel) renderStatusBar() string {
-	var content string
+	var hints string
 	switch m.mode.(type) {
 	case settingsBrowsing:
-		content = "Enter to change • Tab/1-3 switch tabs • q quit"
+		hints = "Enter to change • Tab/1-3 switch tabs • q quit"
 	case settingsPicking:
-		content = "↑/↓ navigate • type to filter • Esc cancel"
+		hints = "↑/↓ navigate • type to filter • Esc cancel"
 	}
 
+	var right string
 	if m.lastErr != "" {
-		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
-		content += " • " + errStyle.Render("error: "+m.lastErr)
+		right = statusBarRed.Render("error: " + m.lastErr)
 	}
 
-	return content
+	return renderStatusBar(m.width, hints, right)
 }
 
 // InputActive returns true when the currency picker is open.

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -22,6 +22,7 @@ type (
 		all      []store.Currency
 		filtered []store.Currency
 		cursor   int
+		offset   int // viewport offset for scrolling
 	}
 )
 
@@ -71,7 +72,7 @@ func NewSettingsModel(ctx context.Context, s store.Store, c api.CoinGeckoClient)
 
 // Init returns the initial command to load settings data.
 func (m SettingsModel) Init() tea.Cmd {
-	return cmdLoadSettings(m.store)
+	return m.cmdLoadSettings()
 }
 
 // update is the internal update function that handles messages.
@@ -89,7 +90,7 @@ func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 
 	case settingsNeedFetchMsg:
 		m.loading = true
-		return m, cmdFetchCurrencies(m.client)
+		return m, m.cmdFetchCurrencies()
 
 	case currenciesFetchedMsg:
 		// Filter API codes against fiat map
@@ -101,7 +102,7 @@ func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 				Name: api.FiatCurrencies[code],
 			}
 		}
-		return m, cmdUpsertCurrencies(m.store, currencies)
+		return m, m.cmdUpsertCurrencies(currencies)
 
 	case currenciesUpsertedMsg:
 		m.currencies = msg.currencies
@@ -112,11 +113,16 @@ func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 	case tea.KeyMsg:
 		switch mode := m.mode.(type) {
 		case settingsBrowsing:
-			if msg.Type == tea.KeyEnter {
+			switch msg.Type {
+			case tea.KeyEnter:
 				if len(m.currencies) == 0 {
 					return m, func() tea.Msg { return settingsNeedFetchMsg{} }
 				}
 				m.mode = m.makePickingMode(m.currencies)
+			case tea.KeyEscape:
+				// Return focus to tab bar - this is handled by AppModel
+				// The tab itself doesn't need to do anything special
+				return m, nil
 			}
 
 		case settingsPicking:
@@ -131,6 +137,22 @@ func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 				// No-op for Slice 13 - selection handled in Slice 14
 				return m, nil
 
+			case tea.KeyDown:
+				if picking.cursor < len(picking.filtered)-1 {
+					picking.cursor++
+				}
+				picking.adjustViewport(m.height)
+				m.mode = picking
+				return m, nil
+
+			case tea.KeyUp:
+				if picking.cursor > 0 {
+					picking.cursor--
+				}
+				picking.adjustViewport(m.height)
+				m.mode = picking
+				return m, nil
+
 			case tea.KeyRunes:
 				for _, r := range msg.Runes {
 					switch r {
@@ -138,17 +160,31 @@ func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 						if picking.cursor < len(picking.filtered)-1 {
 							picking.cursor++
 						}
+						picking.adjustViewport(m.height)
 						m.mode = picking
 						return m, nil
 					case 'k', 'K':
 						if picking.cursor > 0 {
 							picking.cursor--
 						}
+						picking.adjustViewport(m.height)
 						m.mode = picking
 						return m, nil
 					}
 				}
 				// Forward to filter input
+				var cmd tea.Cmd
+				picking.filter, cmd = picking.filter.Update(msg)
+				picking.filtered = filterCurrencies(picking.all, picking.filter.Value())
+				// Clamp cursor
+				if picking.cursor >= len(picking.filtered) && len(picking.filtered) > 0 {
+					picking.cursor = len(picking.filtered) - 1
+				}
+				m.mode = picking
+				return m, cmd
+
+			default:
+				// Forward all other keys (Backspace, Delete, etc.) to filter input
 				var cmd tea.Cmd
 				picking.filter, cmd = picking.filter.Update(msg)
 				picking.filtered = filterCurrencies(picking.all, picking.filter.Value())
@@ -176,6 +212,7 @@ func (m SettingsModel) makePickingMode(currencies []store.Currency) settingsPick
 		all:      currencies,
 		filtered: currencies,
 		cursor:   0,
+		offset:   0,
 	}
 }
 
@@ -195,6 +232,31 @@ func filterCurrencies(currencies []store.Currency, filter string) []store.Curren
 	return result
 }
 
+// adjustViewport updates offset so the cursor stays visible.
+// Reserves 4 lines for header, filter input, and status bar.
+func (p *settingsPicking) adjustViewport(height int) {
+	visibleRows := height - 4
+	if visibleRows < 1 {
+		visibleRows = 1
+	}
+	if p.cursor < p.offset {
+		p.offset = p.cursor
+	}
+	if p.cursor >= p.offset+visibleRows {
+		p.offset = p.cursor - visibleRows + 1
+	}
+	maxOffset := len(p.filtered) - visibleRows
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if p.offset > maxOffset {
+		p.offset = maxOffset
+	}
+	if p.offset < 0 {
+		p.offset = 0
+	}
+}
+
 // View renders the Settings tab content.
 func (m SettingsModel) View() string {
 	switch mode := m.mode.(type) {
@@ -209,7 +271,7 @@ func (m SettingsModel) View() string {
 
 func (m SettingsModel) viewBrowsing() string {
 	if m.loading {
-		return "Loading currencies…"
+		return "Loading currencies…\n" + m.renderStatusBar()
 	}
 
 	var b strings.Builder
@@ -220,9 +282,6 @@ func (m SettingsModel) viewBrowsing() string {
 		currencyName = name
 	}
 	_, _ = fmt.Fprintf(&b, "Base Currency: %s (%s)\n", strings.ToUpper(m.selectedCode), currencyName)
-	b.WriteString("\n")
-	b.WriteString("Press Enter to change currency\n")
-	b.WriteString("Press Tab to switch tabs, q to quit\n")
 
 	if m.lastErr != "" {
 		b.WriteString("\n")
@@ -230,7 +289,17 @@ func (m SettingsModel) viewBrowsing() string {
 		b.WriteString(errStyle.Render("Error: " + m.lastErr))
 	}
 
-	return b.String()
+	content := b.String()
+
+	// Render with panel border for visual framing
+	accentColor := lipgloss.Color("#00FFFF")
+	panelStyle := lipgloss.NewStyle().
+		Width(m.width - 2).
+		Height(m.height - 2).
+		Border(lipgloss.NormalBorder()).
+		BorderForeground(accentColor)
+
+	return panelStyle.Render(content) + "\n" + m.renderStatusBar()
 }
 
 func (m SettingsModel) viewPicking(picking settingsPicking) string {
@@ -244,11 +313,22 @@ func (m SettingsModel) viewPicking(picking settingsPicking) string {
 	b.WriteString(picking.filter.View())
 	b.WriteString("\n\n")
 
-	// Currency list
+	// Currency list with viewport
 	if len(picking.filtered) == 0 {
 		b.WriteString("No currencies match your search.\n")
 	} else {
-		for i, c := range picking.filtered {
+		// Calculate visible range
+		visibleRows := m.height - 8 // Reserve space for header, filter, borders, status
+		if visibleRows < 1 {
+			visibleRows = 1
+		}
+		end := picking.offset + visibleRows
+		if end > len(picking.filtered) {
+			end = len(picking.filtered)
+		}
+
+		for i := picking.offset; i < end; i++ {
+			c := picking.filtered[i]
 			line := fmt.Sprintf("  %s - %s", strings.ToUpper(c.Code), c.Name)
 			if i == picking.cursor {
 				// Highlight selected
@@ -261,10 +341,31 @@ func (m SettingsModel) viewPicking(picking settingsPicking) string {
 		}
 	}
 
-	b.WriteString("\n")
-	b.WriteString("j/k to navigate, type to filter, Enter to select (disabled), Esc to cancel\n")
+	dialog := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		Padding(1, 2).
+		Render(b.String())
 
-	return b.String()
+	content := lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, dialog)
+	return content + "\n" + m.renderStatusBar()
+}
+
+// renderStatusBar returns a status bar with keyboard hints.
+func (m SettingsModel) renderStatusBar() string {
+	var content string
+	switch m.mode.(type) {
+	case settingsBrowsing:
+		content = "Enter to change • Tab/1-3 switch tabs • Esc back to tabs • q quit"
+	case settingsPicking:
+		content = "j/k/↑/↓ navigate • type to filter • Esc cancel"
+	}
+
+	if m.lastErr != "" {
+		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
+		content += " • " + errStyle.Render("error: "+m.lastErr)
+	}
+
+	return content
 }
 
 // InputActive returns true when the currency picker is open.
@@ -274,14 +375,13 @@ func (m SettingsModel) InputActive() bool {
 }
 
 // cmdLoadSettings creates a command to load settings from the database.
-func cmdLoadSettings(s store.Store) tea.Cmd {
+func (m SettingsModel) cmdLoadSettings() tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
-		currencies, err := s.GetAllCurrencies(ctx)
+		currencies, err := m.store.GetAllCurrencies(m.ctx)
 		if err != nil {
 			return errMsg{err: err}
 		}
-		selected, err := s.GetSetting(ctx, "selected_currency")
+		selected, err := m.store.GetSetting(m.ctx, "selected_currency")
 		if err != nil {
 			return errMsg{err: err}
 		}
@@ -293,10 +393,9 @@ func cmdLoadSettings(s store.Store) tea.Cmd {
 }
 
 // cmdFetchCurrencies creates a command to fetch supported currencies from the API.
-func cmdFetchCurrencies(client api.CoinGeckoClient) tea.Cmd {
+func (m SettingsModel) cmdFetchCurrencies() tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
-		codes, err := client.FetchSupportedCurrencies(ctx)
+		codes, err := m.client.FetchSupportedCurrencies(m.ctx)
 		if err != nil {
 			return errMsg{err: err}
 		}
@@ -305,10 +404,9 @@ func cmdFetchCurrencies(client api.CoinGeckoClient) tea.Cmd {
 }
 
 // cmdUpsertCurrencies creates a command to persist currencies to the database.
-func cmdUpsertCurrencies(s store.Store, currencies []store.Currency) tea.Cmd {
+func (m SettingsModel) cmdUpsertCurrencies(currencies []store.Currency) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
-		if err := s.UpsertCurrencies(ctx, currencies); err != nil {
+		if err := m.store.UpsertCurrencies(m.ctx, currencies); err != nil {
 			return errMsg{err: err}
 		}
 		return currenciesUpsertedMsg{currencies: currencies}

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -106,7 +106,7 @@ func TestSettingsEnterTriggersFetchWhenNoCurrencies(t *testing.T) {
 	}
 }
 
-func TestSettingsPickJkNavigation(t *testing.T) {
+func TestSettingsPickArrowNavigation(t *testing.T) {
 	currencies := []store.Currency{
 		{Code: "usd", Name: "US Dollar"},
 		{Code: "eur", Name: "Euro"},
@@ -125,18 +125,18 @@ func TestSettingsPickJkNavigation(t *testing.T) {
 		t.Errorf("expected cursor at 0 initially, got %d", picking.cursor)
 	}
 
-	// Press j to move down
-	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	// Press Down to move down
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyDown})
 	picking = m.mode.(settingsPicking)
 	if picking.cursor != 1 {
-		t.Errorf("expected cursor at 1 after j, got %d", picking.cursor)
+		t.Errorf("expected cursor at 1 after Down, got %d", picking.cursor)
 	}
 
-	// Press k to move up
-	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	// Press Up to move up
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyUp})
 	picking = m.mode.(settingsPicking)
 	if picking.cursor != 0 {
-		t.Errorf("expected cursor at 0 after k, got %d", picking.cursor)
+		t.Errorf("expected cursor at 0 after Up, got %d", picking.cursor)
 	}
 }
 
@@ -228,8 +228,8 @@ func TestSettingsPickCursorClampsAtTop(t *testing.T) {
 	// Enter picking mode
 	m, _ = m.update(tea.KeyMsg{Type: tea.KeyEnter})
 
-	// Press k when at top
-	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	// Press Up when at top
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyUp})
 	picking := m.mode.(settingsPicking)
 
 	if picking.cursor != 0 {
@@ -250,12 +250,12 @@ func TestSettingsPickCursorClampsAtBottom(t *testing.T) {
 	// Enter picking mode
 	m, _ = m.update(tea.KeyMsg{Type: tea.KeyEnter})
 
-	// Move to last item
-	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	// Move to last item using Down arrow
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyDown})
 
 	// Try to move past end
-	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyDown})
 	picking := m.mode.(settingsPicking)
 
 	if picking.cursor != 1 {

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -83,9 +83,7 @@ func TestSettingsEnterOpensPickerWhenCurrenciesAvailable(t *testing.T) {
 }
 
 func TestSettingsEnterTriggersFetchWhenNoCurrencies(t *testing.T) {
-	stub := &StubStore{
-		supportedCurrencies: []string{"usd", "eur", "btc"},
-	}
+	stub := &StubStore{}
 	api := &StubAPI{
 		supportedCurrencies: []string{"usd", "eur", "btc"},
 	}

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -1,0 +1,394 @@
+package ui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/fredericomozzato/crypto_tracker/internal/store"
+)
+
+func TestNewSettingsModel(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewSettingsModel(context.Background(), stub, api)
+
+	// Should start in browsing mode
+	if m.InputActive() {
+		t.Error("expected InputActive to be false in browsing mode")
+	}
+
+	// Should have default currency
+	if m.selectedCode != "usd" {
+		t.Errorf("expected default selectedCode 'usd', got %s", m.selectedCode)
+	}
+}
+
+func TestSettingsInputActiveFalseWhenBrowsing(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewSettingsModel(context.Background(), stub, api)
+
+	if m.InputActive() {
+		t.Error("expected InputActive() to return false in browsing mode")
+	}
+}
+
+func TestSettingsInputActiveTrueWhenPicking(t *testing.T) {
+	stub := &StubStore{
+		currencies: []store.Currency{
+			{Code: "usd", Name: "US Dollar"},
+			{Code: "eur", Name: "Euro"},
+		},
+	}
+	api := &StubAPI{}
+	m := NewSettingsModel(context.Background(), stub, api)
+
+	// Simulate loading currencies and pressing Enter
+	m.currencies = stub.currencies
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	updated, _ := m.update(msg)
+	m = updated
+
+	if !m.InputActive() {
+		t.Error("expected InputActive() to return true in picking mode")
+	}
+}
+
+func TestSettingsEnterOpensPickerWhenCurrenciesAvailable(t *testing.T) {
+	stub := &StubStore{
+		currencies: []store.Currency{
+			{Code: "usd", Name: "US Dollar"},
+			{Code: "eur", Name: "Euro"},
+		},
+	}
+	api := &StubAPI{}
+	m := NewSettingsModel(context.Background(), stub, api)
+	m.currencies = stub.currencies
+
+	// Should be in browsing mode initially
+	if m.InputActive() {
+		t.Error("expected browsing mode initially")
+	}
+
+	// Press Enter to open picker
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	updated, _ := m.update(msg)
+	m = updated
+
+	if !m.InputActive() {
+		t.Error("expected picking mode after Enter")
+	}
+}
+
+func TestSettingsEnterTriggersFetchWhenNoCurrencies(t *testing.T) {
+	stub := &StubStore{
+		supportedCurrencies: []string{"usd", "eur", "btc"},
+	}
+	api := &StubAPI{
+		supportedCurrencies: []string{"usd", "eur", "btc"},
+	}
+	m := NewSettingsModel(context.Background(), stub, api)
+	m.currencies = []store.Currency{} // Empty currencies
+
+	// Press Enter with no currencies - should produce settingsNeedFetchMsg
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	_, cmd := m.update(msg)
+
+	if cmd == nil {
+		t.Fatal("expected command from Enter when currencies empty")
+	}
+
+	result := cmd()
+	if _, ok := result.(settingsNeedFetchMsg); !ok {
+		t.Errorf("expected settingsNeedFetchMsg, got %T", result)
+	}
+}
+
+func TestSettingsPickJkNavigation(t *testing.T) {
+	currencies := []store.Currency{
+		{Code: "usd", Name: "US Dollar"},
+		{Code: "eur", Name: "Euro"},
+		{Code: "gbp", Name: "British Pound"},
+	}
+	stub := &StubStore{currencies: currencies}
+	api := &StubAPI{}
+	m := NewSettingsModel(context.Background(), stub, api)
+	m.currencies = currencies
+
+	// Enter picking mode
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	picking := m.mode.(settingsPicking)
+	if picking.cursor != 0 {
+		t.Errorf("expected cursor at 0 initially, got %d", picking.cursor)
+	}
+
+	// Press j to move down
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	picking = m.mode.(settingsPicking)
+	if picking.cursor != 1 {
+		t.Errorf("expected cursor at 1 after j, got %d", picking.cursor)
+	}
+
+	// Press k to move up
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	picking = m.mode.(settingsPicking)
+	if picking.cursor != 0 {
+		t.Errorf("expected cursor at 0 after k, got %d", picking.cursor)
+	}
+}
+
+func TestSettingsPickFilterReducesList(t *testing.T) {
+	currencies := []store.Currency{
+		{Code: "usd", Name: "US Dollar"},
+		{Code: "eur", Name: "Euro"},
+		{Code: "gbp", Name: "British Pound"},
+	}
+	stub := &StubStore{currencies: currencies}
+	api := &StubAPI{}
+	m := NewSettingsModel(context.Background(), stub, api)
+	m.currencies = currencies
+
+	// Enter picking mode
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyEnter})
+	picking := m.mode.(settingsPicking)
+
+	if len(picking.filtered) != 3 {
+		t.Fatalf("expected 3 currencies initially, got %d", len(picking.filtered))
+	}
+
+	// Type "eu" to filter
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e', 'u'}})
+	picking = m.mode.(settingsPicking)
+
+	if len(picking.filtered) != 1 {
+		t.Errorf("expected 1 currency after filtering 'eu', got %d", len(picking.filtered))
+	}
+
+	if picking.filtered[0].Code != "eur" {
+		t.Errorf("expected eur, got %s", picking.filtered[0].Code)
+	}
+}
+
+func TestSettingsPickEscReturnsToBrowsing(t *testing.T) {
+	currencies := []store.Currency{
+		{Code: "usd", Name: "US Dollar"},
+	}
+	stub := &StubStore{currencies: currencies}
+	api := &StubAPI{}
+	m := NewSettingsModel(context.Background(), stub, api)
+	m.currencies = currencies
+
+	// Enter picking mode
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !m.InputActive() {
+		t.Fatal("expected picking mode")
+	}
+
+	// Press Esc
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyEscape})
+
+	if m.InputActive() {
+		t.Error("expected browsing mode after Esc")
+	}
+}
+
+func TestSettingsPickEnterNoOp(t *testing.T) {
+	currencies := []store.Currency{
+		{Code: "usd", Name: "US Dollar"},
+	}
+	stub := &StubStore{currencies: currencies}
+	api := &StubAPI{}
+	m := NewSettingsModel(context.Background(), stub, api)
+	m.currencies = currencies
+
+	// Enter picking mode
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Press Enter - should be no-op (Slice 14 wires it)
+	_, cmd := m.update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if cmd != nil {
+		t.Error("expected no command from Enter in picking mode (Slice 13)")
+	}
+}
+
+func TestSettingsPickCursorClampsAtTop(t *testing.T) {
+	currencies := []store.Currency{
+		{Code: "usd", Name: "US Dollar"},
+		{Code: "eur", Name: "Euro"},
+	}
+	stub := &StubStore{currencies: currencies}
+	api := &StubAPI{}
+	m := NewSettingsModel(context.Background(), stub, api)
+	m.currencies = currencies
+
+	// Enter picking mode
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Press k when at top
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	picking := m.mode.(settingsPicking)
+
+	if picking.cursor != 0 {
+		t.Errorf("expected cursor to stay at 0, got %d", picking.cursor)
+	}
+}
+
+func TestSettingsPickCursorClampsAtBottom(t *testing.T) {
+	currencies := []store.Currency{
+		{Code: "usd", Name: "US Dollar"},
+		{Code: "eur", Name: "Euro"},
+	}
+	stub := &StubStore{currencies: currencies}
+	api := &StubAPI{}
+	m := NewSettingsModel(context.Background(), stub, api)
+	m.currencies = currencies
+
+	// Enter picking mode
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Move to last item
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+
+	// Try to move past end
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	picking := m.mode.(settingsPicking)
+
+	if picking.cursor != 1 {
+		t.Errorf("expected cursor to stay at 1, got %d", picking.cursor)
+	}
+}
+
+func TestSettingsBrowsingShowsSelectedCurrency(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewSettingsModel(context.Background(), stub, api)
+	m.selectedCode = "eur"
+	m.currencies = []store.Currency{
+		{Code: "eur", Name: "Euro"},
+	}
+
+	view := m.View()
+
+	if !strings.Contains(view, "EUR") {
+		t.Errorf("expected view to contain 'EUR', got %q", view)
+	}
+}
+
+func TestSettingsLoadedMsgUpdatesState(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewSettingsModel(context.Background(), stub, api)
+
+	currencies := []store.Currency{
+		{Code: "gbp", Name: "British Pound"},
+	}
+
+	msg := settingsLoadedMsg{
+		currencies: currencies,
+		selected:   "gbp",
+	}
+
+	updated, _ := m.update(msg)
+	m = updated
+
+	if len(m.currencies) != 1 {
+		t.Errorf("expected 1 currency, got %d", len(m.currencies))
+	}
+
+	if m.selectedCode != "gbp" {
+		t.Errorf("expected selectedCode 'gbp', got %s", m.selectedCode)
+	}
+}
+
+func TestCurrenciesUpsertedMsgTransitionsToPicking(t *testing.T) {
+	currencies := []store.Currency{
+		{Code: "usd", Name: "US Dollar"},
+	}
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewSettingsModel(context.Background(), stub, api)
+	m.loading = true
+
+	msg := currenciesUpsertedMsg{currencies: currencies}
+	updated, _ := m.update(msg)
+	m = updated
+
+	if m.loading {
+		t.Error("expected loading to be false after currenciesUpsertedMsg")
+	}
+
+	if !m.InputActive() {
+		t.Error("expected picking mode after currenciesUpsertedMsg")
+	}
+
+	if len(m.currencies) != 1 {
+		t.Errorf("expected 1 currency, got %d", len(m.currencies))
+	}
+}
+
+func TestFilterCurrenciesEmptyFilter(t *testing.T) {
+	currencies := []store.Currency{
+		{Code: "usd", Name: "US Dollar"},
+		{Code: "eur", Name: "Euro"},
+	}
+
+	result := filterCurrencies(currencies, "")
+
+	if len(result) != 2 {
+		t.Errorf("expected 2 currencies with empty filter, got %d", len(result))
+	}
+}
+
+func TestFilterCurrenciesByCode(t *testing.T) {
+	currencies := []store.Currency{
+		{Code: "usd", Name: "US Dollar"},
+		{Code: "eur", Name: "Euro"},
+		{Code: "gbp", Name: "British Pound"},
+	}
+
+	result := filterCurrencies(currencies, "us")
+
+	if len(result) != 1 {
+		t.Errorf("expected 1 currency matching 'us', got %d", len(result))
+	}
+
+	if result[0].Code != "usd" {
+		t.Errorf("expected usd, got %s", result[0].Code)
+	}
+}
+
+func TestFilterCurrenciesByName(t *testing.T) {
+	currencies := []store.Currency{
+		{Code: "usd", Name: "US Dollar"},
+		{Code: "eur", Name: "Euro"},
+		{Code: "gbp", Name: "British Pound"},
+	}
+
+	result := filterCurrencies(currencies, "pound")
+
+	if len(result) != 1 {
+		t.Errorf("expected 1 currency matching 'pound', got %d", len(result))
+	}
+
+	if result[0].Code != "gbp" {
+		t.Errorf("expected gbp, got %s", result[0].Code)
+	}
+}
+
+func TestFilterCurrenciesNoMatches(t *testing.T) {
+	currencies := []store.Currency{
+		{Code: "usd", Name: "US Dollar"},
+		{Code: "eur", Name: "Euro"},
+	}
+
+	result := filterCurrencies(currencies, "xyz")
+
+	if len(result) != 0 {
+		t.Errorf("expected 0 currencies matching 'xyz', got %d", len(result))
+	}
+}

--- a/internal/ui/statusbar.go
+++ b/internal/ui/statusbar.go
@@ -1,0 +1,27 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	statusBarGray   = lipgloss.NewStyle().Foreground(lipgloss.Color("#888888"))
+	statusBarRed    = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF4444"))
+	statusBarGreen  = lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00"))
+	statusBarYellow = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFD700"))
+	statusBarOrange = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF8C00"))
+)
+
+// renderStatusBar renders a full-width status bar with left-aligned keyboard
+// hints (rendered in gray) and an optional pre-styled right-aligned section.
+// The right parameter must be pre-styled by the caller.
+func renderStatusBar(width int, left, right string) string {
+	leftStyled := statusBarGray.Render(left)
+	padding := width - lipgloss.Width(left) - lipgloss.Width(right)
+	if padding < 1 {
+		padding = 1
+	}
+	return leftStyled + strings.Repeat(" ", padding) + right
+}

--- a/internal/ui/testhelpers_test.go
+++ b/internal/ui/testhelpers_test.go
@@ -11,13 +11,12 @@ import (
 
 // StubStore implements store.Store for testing
 type StubStore struct {
-	coins               []store.Coin
-	portfolios          []store.Portfolio
-	holdingRows         []store.HoldingRow
-	currencies          []store.Currency
-	supportedCurrencies []string
-	settings            map[string]string
-	err                 error
+	coins       []store.Coin
+	portfolios  []store.Portfolio
+	holdingRows []store.HoldingRow
+	currencies  []store.Currency
+	settings    map[string]string
+	err         error
 }
 
 func (s *StubStore) UpsertCoin(ctx context.Context, c store.Coin) error {

--- a/internal/ui/testhelpers_test.go
+++ b/internal/ui/testhelpers_test.go
@@ -14,6 +14,8 @@ type StubStore struct {
 	coins       []store.Coin
 	portfolios  []store.Portfolio
 	holdingRows []store.HoldingRow
+	currencies  []store.Currency
+	settings    map[string]string
 	err         error
 }
 
@@ -104,12 +106,52 @@ func (s *StubStore) DeletePortfolio(ctx context.Context, id int64) error {
 	return nil
 }
 
+func (s *StubStore) UpsertCurrencies(ctx context.Context, currencies []store.Currency) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.currencies = currencies
+	return nil
+}
+
+func (s *StubStore) GetAllCurrencies(ctx context.Context) ([]store.Currency, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.currencies == nil {
+		return []store.Currency{}, nil
+	}
+	return s.currencies, nil
+}
+
+func (s *StubStore) GetSetting(ctx context.Context, key string) (string, error) {
+	if s.err != nil {
+		return "", s.err
+	}
+	if s.settings == nil {
+		return "", nil
+	}
+	return s.settings[key], nil
+}
+
+func (s *StubStore) SetSetting(ctx context.Context, key, value string) error {
+	if s.err != nil {
+		return s.err
+	}
+	if s.settings == nil {
+		s.settings = make(map[string]string)
+	}
+	s.settings[key] = value
+	return nil
+}
+
 // StubAPI implements api.CoinGeckoClient for testing
 type StubAPI struct {
-	coins             []store.Coin
-	prices            map[string]float64
-	err               error
-	fetchMarketsCalls []int
+	coins               []store.Coin
+	prices              map[string]float64
+	supportedCurrencies []string
+	err                 error
+	fetchMarketsCalls   []int
 }
 
 func (a *StubAPI) FetchMarkets(ctx context.Context, limit int) ([]store.Coin, error) {
@@ -125,6 +167,13 @@ func (a *StubAPI) FetchPrices(ctx context.Context, apiIDs []string) (map[string]
 		return nil, a.err
 	}
 	return a.prices, nil
+}
+
+func (a *StubAPI) FetchSupportedCurrencies(ctx context.Context) ([]string, error) {
+	if a.err != nil {
+		return nil, a.err
+	}
+	return a.supportedCurrencies, nil
 }
 
 func threeCoins() []store.Coin {

--- a/internal/ui/testhelpers_test.go
+++ b/internal/ui/testhelpers_test.go
@@ -11,12 +11,13 @@ import (
 
 // StubStore implements store.Store for testing
 type StubStore struct {
-	coins       []store.Coin
-	portfolios  []store.Portfolio
-	holdingRows []store.HoldingRow
-	currencies  []store.Currency
-	settings    map[string]string
-	err         error
+	coins               []store.Coin
+	portfolios          []store.Portfolio
+	holdingRows         []store.HoldingRow
+	currencies          []store.Currency
+	supportedCurrencies []string
+	settings            map[string]string
+	err                 error
 }
 
 func (s *StubStore) UpsertCoin(ctx context.Context, c store.Coin) error {


### PR DESCRIPTION
## Summary

- Add `currencies` and `settings` DB tables (`schema.sql`) with `selected_currency = 'usd'` seeded on init
- Add `Currency` type and `UpsertCurrencies` / `GetAllCurrencies` / `GetSetting` / `SetSetting` to `Store` interface and `SQLiteStore`
- Add `CoinGeckoClient.FetchSupportedCurrencies(ctx) ([]string, error)` — hits `/simple/supported_vs_currencies` and returns raw code list
- Add `internal/api/fiat.go` — hardcoded map of ~35 fiat currencies and `FilterFiat()` to intersect with API response
- On first launch: async `FetchSupportedCurrencies` → `FilterFiat` → `UpsertCurrencies`; Settings tab shows "Loading currencies…" until available
- New `internal/ui/settings.go` — `SettingsModel` with browsing and picking modes, searchable currency picker with scroll viewport
- `AppModel` gains 3rd tab (Settings), `3` key, updated tab bar, `InputActive()` suppresses tab switching when picker is open
- Arrow-key-only navigation in picker (no j/k conflict with filter typing), `Esc` returns to browsing/tab bar
- Handle `errMsg` in Settings model, use model's `ctx` in all command closures
- Mark slice 013 as IN_REVIEW in roadmap

## Test Plan

- [x] `make check` passes (fmt, lint, test, vuln)
- [x] Store CRUD for currencies and settings tested with real SQLite (`t.TempDir`)
- [x] `FetchSupportedCurrencies` tested via `httptest.NewServer` (success, API key, 429 rate limit, network error)
- [x] `FilterFiat` tested (intersection, empty input, all-fiat, partial match)
- [x] Settings model state transitions tested (browsing ↔ picking, search/filter, viewport scrolling)
- [x] AppModel 3-tab rendering tested (tab bar, Settings tab display, key routing)
- [x] No real network requests in any test