### PR TITLE
feat(slice-014): currency selection with correct price display

### DIFF
--- a/docs/issues/013-settings-tab-currency-data-layer.md
+++ b/docs/issues/013-settings-tab-currency-data-layer.md
@@ -1,5 +1,5 @@
 ---
-status: in_review
+status: done
 branch: feat/013-settings-tab-currency-data-layer
 ---
 

--- a/docs/issues/014-currency-selection-correct-price-display.md
+++ b/docs/issues/014-currency-selection-correct-price-display.md
@@ -1,0 +1,345 @@
+---
+status: in_review
+branch: feat/014-currency-selection-correct-price-display
+---
+
+# Slice 14 — Currency selection + correct price display
+
+## Context
+
+Slice 13 (DONE) delivered the Settings tab infrastructure: `currencies` and `settings` DB tables, `FetchSupportedCurrencies` API method, `Store` CRUD for settings/currencies, and a searchable currency picker dialog. The picker's `Enter` handler is a **no-op** awaiting Slice 14. All prices in Markets and Portfolio are hardcoded to USD. `FmtPrice`/`FmtMoney` hardcode the `$` symbol prefix.
+
+This slice wires currency selection end-to-end: pick a currency → persist it → re-fetch data in that currency → display everywhere with the correct uppercase currency ticker (e.g. `USD`, `EUR`, `BRL`) as a prefix. Portfolio totals and computed values (value, proportion) must reflect the new currency after prices are updated in the DB.
+
+## Scope
+
+From the roadmap:
+
+1. `FetchMarkets(ctx, currency, limit)` and `FetchPrices(ctx, apiIDs, currency)` — add `currency string` parameter
+2. `FetchPrices` response parsing uses dynamic key (`currency`) instead of hardcoded `"usd"`
+3. `format.FmtPrice(currency, v)` and `format.FmtMoney(currency, v)` — currency code as prefix
+4. Picking mode `Enter` selects the highlighted currency: persists to DB, triggers refresh, returns to browsing
+5. Markets tab reads selected currency from model state and passes it through `FmtPrice`/`FmtChange`
+6. Portfolio tab passes currency to `FmtPrice`/`FmtMoney` for Price, Value, and total columns
+7. Auto-refresh always uses the current `selected_currency`
+8. App init reads `selected_currency` from DB (default `"usd"`) before first fetch
+
+## Data model
+
+**No schema changes.** The `settings` table with `selected_currency` already exists from Slice 13.
+
+## Files to create/modify
+
+### 1. `internal/format/format.go` — Currency-aware formatting
+
+Always use the uppercase 3-letter currency code as the prefix — never a currency symbol. For example: `USD 84,321.45`, `EUR 0.001234`, `BRL 1,500.50`. This keeps formatting consistent and unambiguous across all currencies.
+
+The `$` prefix currently used is replaced with the uppercase ticker. `FmtPrice` and `FmtMoney` gain a `currency string` parameter. The helper `currencyCode` lowercases the input for comparison, then returns the uppercase version:
+
+```go
+func currencyCode(currency string) string {
+    return strings.ToUpper(currency)
+}
+
+func FmtPrice(v float64, currency string) string {
+    prefix := currencyCode(currency)
+    if v >= 1 {
+        parts := strings.SplitN(fmt.Sprintf("%.2f", v), ".", 2)
+        return prefix + " " + addCommas(parts[0]) + "." + parts[1]
+    }
+    return fmt.Sprintf("%s %.6f", prefix, v)
+}
+
+func FmtMoney(v float64, currency string) string {
+    parts := strings.SplitN(fmt.Sprintf("%.2f", v), ".", 2)
+    return currencyCode(currency) + " " + addCommas(parts[0]) + "." + parts[1]
+}
+```
+
+`FmtChange` remains unchanged (percentages are currency-agnostic).
+
+### 2. `internal/api/coingecko.go` — Add `currency` parameter
+
+**Interface change:**
+
+```go
+type CoinGeckoClient interface {
+    FetchMarkets(ctx context.Context, currency string, limit int) ([]store.Coin, error)
+    FetchPrices(ctx context.Context, apiIDs []string, currency string) (map[string]float64, error)
+    FetchSupportedCurrencies(ctx context.Context) ([]string, error)
+}
+```
+
+**`FetchMarkets` implementation:** Replace `params.Set("vs_currency", "usd")` with `params.Set("vs_currency", currency)`.
+
+**`FetchPrices` implementation:** Replace `params.Set("vs_currencies", "usd")` with `params.Set("vs_currencies", currency)`. Replace hardcoded `"usd"` key extraction with `currency`:
+
+```go
+for apiID, priceData := range apiResp {
+    if price, ok := priceData[currency]; ok {
+        prices[apiID] = price
+    }
+}
+```
+
+### 3. `internal/ui/settings.go` — Wire up currency selection
+
+Add a new message type:
+
+```go
+type currencyChangedMsg struct {
+    code string
+}
+```
+
+In `settingsPicking` `KeyEnter` handler (currently a no-op on line 141), replace with:
+
+```go
+case tea.KeyEnter:
+    if len(picking.filtered) == 0 {
+        return m, nil
+    }
+    selected := picking.filtered[picking.cursor]
+    if err := m.store.SetSetting(m.ctx, "selected_currency", selected.Code); err != nil {
+        m.lastErr = err.Error()
+        return m, nil
+    }
+    m.selectedCode = selected.Code
+    m.mode = settingsBrowsing{}
+    return m, func() tea.Msg { return currencyChangedMsg{code: selected.Code} }
+```
+
+Update `viewBrowsing()` to show the currency code:
+
+```go
+line := fmt.Sprintf("  Base Currency: %s (%s)", strings.ToUpper(m.selectedCode), currencyName)
+```
+
+### 4. `internal/ui/app.go` — Propagate currency change + init currency
+
+Add `currency string` field to `AppModel`. Read from DB on init:
+
+```go
+func NewAppModel(ctx context.Context, s store.Store, c api.CoinGeckoClient) AppModel {
+    currency, _ := s.GetSetting(ctx, "selected_currency")
+    if currency == "" {
+        currency = "usd"
+    }
+    return AppModel{
+        activeTab: tabMarkets,
+        markets:   NewMarketsModel(ctx, s, c, currency),
+        portfolio: NewPortfolioModel(ctx, s, currency),
+        settings:  NewSettingsModel(ctx, s, c),
+        currency:  currency,
+    }
+}
+```
+
+Handle `currencyChangedMsg` in `Update` — update `m.currency`:
+
+```go
+case currencyChangedMsg:
+    m.currency = msg.code
+    // Falls through to broadcast, which delivers the message to all children
+```
+
+The message is already broadcast to all children via the existing fan-out (lines 115-119), so no additional dispatch needed. `MaketsModel` and `PortfolioModel` each handle it in their own `update` method.
+
+### 5. `internal/ui/markets.go` — Currency-aware markets
+
+Add `currency string` field to `MarketsModel`. Change constructor:
+
+```go
+func NewMarketsModel(ctx context.Context, s store.Store, c api.CoinGeckoClient, currency string) MarketsModel {
+    return MarketsModel{
+        ctx:      ctx,
+        store:    s,
+        client:   c,
+        currency: currency,
+    }
+}
+```
+
+In `update`, add handler for `currencyChangedMsg`:
+
+```go
+case currencyChangedMsg:
+    m.currency = msg.code
+    m.refreshing = true
+    return m, m.cmdRefresh()
+```
+
+In `cmdLoad`, change `m.client.FetchMarkets(m.ctx, coinFetchLimit)` → `m.client.FetchMarkets(m.ctx, m.currency, coinFetchLimit)`.
+
+In `cmdRefresh`, change `m.client.FetchPrices(m.ctx, apiIDs)` → `m.client.FetchPrices(m.ctx, apiIDs, m.currency)`.
+
+In `View()`:
+- Column header: `fmt.Sprintf("Price (%s)", strings.ToUpper(m.currency))` instead of `"Price (USD)"`
+- `format.FmtPrice(c.Rate, m.currency)` instead of `format.FmtPrice(c.Rate)`
+
+### 6. `internal/ui/portfolio.go` — Currency-aware portfolio
+
+Add `currency string` field to `PortfolioModel`. Change constructor:
+
+```go
+func NewPortfolioModel(ctx context.Context, s store.Store, currency string) PortfolioModel {
+    return PortfolioModel{
+        ctx:      ctx,
+        store:    s,
+        currency: currency,
+    }
+}
+```
+
+In `update`, add handlers:
+
+```go
+case currencyChangedMsg:
+    m.currency = msg.code
+    // Don't reload holdings yet — prices in DB are still in the old currency.
+    // When MarketsModel finishes refreshing, pricesUpdatedMsg will be broadcast,
+    // and we'll reload holdings then.
+    return m, nil
+
+case pricesUpdatedMsg:
+    // Prices in the DB have been updated (possibly in a new currency after a
+    // currency change). Reload holdings so Value, Proportion, and totals
+    // reflect the new rates.
+    if len(m.portfolios) > 0 {
+        var cmd tea.Cmd
+        m, cmd = m.update(portfolioReloadMsg{})
+        return m, cmd
+    }
+    return m, nil
+```
+
+(Where `portfolioReloadMsg` or direct reload triggers `cmdLoadHoldings`. The exact mechanism depends on how the existing portfolio reloads — the implementation should use whatever pattern already exists for refreshing holdings data.)
+
+In all rendering, update:
+- `format.FmtPrice(h.Rate, m.currency)` instead of `format.FmtPrice(h.Rate)`
+- `format.FmtMoney(h.Value, m.currency)` instead of `format.FmtMoney(h.Value)`
+- `format.FmtMoney(totalValue, m.currency)` instead of `format.FmtMoney(totalValue)`
+- Column headers should indicate currency: `"Price"` → includes currency context, e.g. display the currency code in the header or total line
+
+### 7. `internal/ui/testhelpers_test.go` — Update StubAPI
+
+Update `FetchMarkets` and `FetchPrices` signatures to match new interface:
+
+```go
+type fetchMarketsCall struct {
+    limit    int
+    currency string
+}
+
+func (a *StubAPI) FetchMarkets(ctx context.Context, currency string, limit int) ([]store.Coin, error) {
+    a.fetchMarketsCalls = append(a.fetchMarketsCalls, fetchMarketsCall{limit: limit, currency: currency})
+    if a.err != nil {
+        return nil, a.err
+    }
+    return a.coins, nil
+}
+
+func (a *StubAPI) FetchPrices(ctx context.Context, apiIDs []string, currency string) (map[string]float64, error) {
+    if a.err != nil {
+        return nil, a.err
+    }
+    return a.prices, nil
+}
+```
+
+### 8. `internal/api/coingecko_test.go` — Update tests
+
+- **`TestFetchMarketsSuccess`**: assert `vs_currency=usd` is sent. Add subtest `TestFetchMarketsWithCurrency`: send `"eur"`, verify `vs_currency=eur` query param.
+- **`TestFetchPricesSuccess`**: assert `vs_currencies=usd`. Add subtest `TestFetchPricesWithCurrency`: server returns `{"bitcoin": {"eur": 62000.00}}`, call `FetchPrices(ctx, ids, "eur")`, verify price is extracted using the `"eur"` key.
+- All existing `FetchMarkets`/`FetchPrices` calls updated with `"usd"` as the currency argument.
+
+### 9. `internal/format/format_test.go` — Update + add tests
+
+All existing `FmtPrice(v)` calls → `FmtPrice(v, "usd")`. All existing `FmtMoney(v)` calls → `FmtMoney(v, "usd")`. Outputs change from `$` prefix to `USD ` prefix (e.g. `"$67,234.56"` → `"USD 67,234.56"`).
+
+New tests:
+
+| Test | Verifies |
+|------|----------|
+| `TestFmtPriceWithEur` | `FmtPrice(1234.56, "eur")` → `"EUR 1,234.56"` |
+| `TestFmtPriceBelowOneWithEur` | `FmtPrice(0.000123, "eur")` → `"EUR 0.000123"` |
+| `TestFmtPriceWithUnknownCurrency` | `FmtPrice(1234.56, "brl")` → `"BRL 1,234.56"` |
+| `TestFmtMoneyWithEur` | `FmtMoney(12345.67, "eur")` → `"EUR 12,345.67"` |
+| `TestFmtMoneyWithJpy` | `FmtMoney(12345.67, "jpy")` → `"JPY 12,345.67"` |
+| `TestCurrencyCodeLowerCase` | `currencyCode("usd")` → `"USD"` |
+| `TestCurrencyCodeUpperCase` | `currencyCode("EUR")` → `"EUR"` |
+
+### 10. `internal/ui/app_test.go` — Add tests
+
+| Test | Verifies |
+|------|----------|
+| `TestAppInitCurrencyDefault` | `NewAppModel` with no `selected_currency` setting defaults `currency` to `"usd"` |
+| `TestAppInitCurrencyFromDB` | `NewAppModel` with `selected_currency=eur` sets `currency` to `"eur"` |
+| `TestCurrencyChangedPropagates` | Sending `currencyChangedMsg{code: "eur"}` updates `AppModel.currency`, and the message reaches all child models |
+
+### 11. `internal/ui/markets_test.go` — Add tests
+
+| Test | Verifies |
+|------|----------|
+| `TestMarketsCurrencyChanged` | `currencyChangedMsg{code: "eur"}` sets `m.currency` to `"eur"`, `m.refreshing` to `true`, and returns a refresh cmd |
+| `TestMarketsViewShowsCurrencyHeader` | After setting `m.currency = "eur"` and loading coins, `View()` contains `"Price (EUR)"` |
+
+### 12. `internal/ui/portfolio_test.go` — Add tests
+
+| Test | Verifies |
+|------|----------|
+| `TestPortfolioCurrencyChanged` | `currencyChangedMsg{code: "eur"}` sets `m.currency` to `"eur"` but does NOT immediately reload holdings |
+| `TestPortfolioPricesUpdatedReloadsHoldings` | `pricesUpdatedMsg` triggers a holdings reload so totals reflect updated rates |
+| `TestPortfolioViewShowsCurrency` | With `m.currency = "eur"` and holdings loaded, `View()` renders `EUR` prefix on prices and values |
+
+### 13. `internal/ui/settings_test.go` — Add tests
+
+| Test | Verifies |
+|------|----------|
+| `TestPickingEnterSelectsCurrency` | In `settingsPicking` mode, pressing `Enter` persists to store, updates `selectedCode`, transitions to `settingsBrowsing`, and returns `currencyChangedMsg` |
+| `TestPickingEnterEmptyFilteredNoop` | Pressing `Enter` when `filtered` list is empty is a no-op |
+| `TestPickingEnterPersistsToStore` | `SetSetting` is called with `"selected_currency"` and the selected code |
+
+## Portfolio total correctness — key design point
+
+When the user selects a new currency, the following sequence must occur:
+
+1. **Settings emits `currencyChangedMsg{code: "eur"}`** after persisting to DB.
+2. **`AppModel` updates `m.currency`** and broadcasts the message to all children.
+3. **`MarketsModel`** receives `currencyChangedMsg` → stores `m.currency = "eur"` → triggers `cmdRefresh()` with the new currency. This fetches prices from the API in EUR and writes them to the `coins` table.
+4. **`PortfolioModel`** receives `currencyChangedMsg` → stores `m.currency = "eur"` → does **NOT** reload holdings yet. The DB still has USD prices.
+5. **`MarketsModel.cmdRefresh`** completes → emits `pricesUpdatedMsg`. This message is broadcast to all children.
+6. **`PortfolioModel`** receives `pricesUpdatedMsg` → reloads holdings from DB. Now `coins.rate` contains EUR prices. Computed `Value = amount * rate` and `Proportion = value / total * 100` are correct in EUR.
+7. All rendering uses `format.FmtPrice(rate, m.currency)` and `format.FmtMoney(value, m.currency)` with the new `"eur"` currency code.
+
+This two-step approach ensures portfolio totals are always computed from the correct currency's prices, avoiding a race condition where holdings would be reloaded before prices are updated.
+
+Additionally, `pricesUpdatedMsg` from auto-refresh (every 60s) also triggers a holdings reload, fixing a pre-existing issue where portfolio values went stale between refreshes.
+
+## Implementation order
+
+1. **`internal/format/format.go`** + **`format_test.go`** — Change `FmtPrice`/`FmtMoney` signatures, add `CurrencyPrefix`, update all tests
+2. **`internal/api/coingecko.go`** + **`coingecko_test.go`** — Add `currency` param to interface + implementation, update response parsing, update all tests
+3. **`internal/ui/testhelpers_test.go`** — Update `StubAPI` signatures to match new interface
+4. **`internal/ui/app.go`** — Add `currency` field, read from DB in `NewAppModel`, handle `currencyChangedMsg`
+5. **`internal/ui/markets.go`** — Add `currency` field, update constructor, handle `currencyChangedMsg`, update API calls, update View header + `FmtPrice` calls
+6. **`internal/ui/portfolio.go`** — Add `currency` field, update constructor, handle `currencyChangedMsg` + `pricesUpdatedMsg`, update `FmtPrice`/`FmtMoney` calls + headers
+7. **`internal/ui/settings.go`** — Wire up `KeyEnter` in picking mode, emit `currencyChangedMsg`
+8. **`internal/ui/app_test.go`**, **`markets_test.go`**, **`portfolio_test.go`**, **`settings_test.go`** — Add/update tests per the test tables above
+9. Run `make check` — all tests pass, lint clean, no race conditions
+
+## Verification
+
+```bash
+make check
+```
+
+Expected: all tests pass, no lint errors, no race conditions, no vulnerability warnings.
+
+Manual smoke test:
+
+1. `go run ./cmd/crypto-tracker` — Markets tab loads in USD
+2. Switch to Settings tab → Enter → pick `EUR` → Enter
+3. Markets tab refreshes with EUR prices, header shows "Price (EUR)"
+4. Portfolio tab shows `EUR` prefix in holdings total, price, and value columns
+5. Switch back to Settings → pick `USD` → everything updates back

--- a/docs/reviews/014-currency-selection-correct-price-display/revision-1.md
+++ b/docs/reviews/014-currency-selection-correct-price-display/revision-1.md
@@ -1,0 +1,59 @@
+---
+branch: feat/014-currency-selection-correct-price-display
+revision: 1
+status: done
+---
+
+# Slice 14 — Currency Selection + Correct Price Display (Revision 1)
+
+## Smoke test + completeness audit
+
+`make check` passes (fmt, lint, test, vuln — all clean). Binary builds successfully. App launches without panic.
+
+However, **scope item 4 is not implemented**: "Picking mode Enter selects the highlighted currency" — the Enter handler in `settingsPicking` mode is still a no-op (`internal/ui/settings.go:140-142`). This makes the entire feature non-functional: the user cannot select a currency at all.
+
+## Feature review
+
+| ID | Sev | Status | Summary |
+|----|-----|--------|---------|
+| F1 | BLOCKER | FIXED | Enter key in currency picker is a no-op — selection never fires |
+| F2 | HIGH | FIXED | Test `TestSettingsPickEnterNoOp` asserts no-op behavior; must be replaced with real selection tests |
+
+**F1** `internal/ui/settings.go:140-142`
+
+The `settingsPicking` KeyEnter handler still contains the Slice 13 placeholder:
+```go
+case tea.KeyEnter:
+    // No-op for Slice 13 - selection handled in Slice 14
+    return m, nil
+```
+
+The issue file specifies it should:
+1. Guard against empty filtered list
+2. Persist `selected_currency` to the settings DB via `m.store.SetSetting()`
+3. Update `m.selectedCode` to the selected currency code
+4. Transition to `settingsBrowsing{}`
+5. Return a `currencyChangedMsg{code: selected.Code}` tea.Cmd
+
+Without this handler, `currencyChangedMsg` is never emitted, so `AppModel.currency` is never updated, `MarketsModel` never re-fetches in the new currency, and `PortfolioModel` never reloads holdings with new prices. The entire currency-selection flow is dead.
+
+**F2** `internal/ui/settings_test.go:196-213`
+
+`TestSettingsPickEnterNoOp` explicitly asserts that Enter in picking mode returns `cmd == nil`. This test must be modified (or replaced) to verify real selection behavior: that `SetSetting` is called, `selectedCode` is updated, mode transitions to browsing, and a `currencyChangedMsg` is returned.
+
+## Implementation review
+
+| ID | Sev | Status | Summary |
+|----|-----|--------|---------|
+| I1 | MED | FIXED | Missing tests for currency propagation as specified in the issue |
+
+**I1** `internal/ui/app_test.go`, `internal/ui/markets_test.go`, `internal/ui/portfolio_test.go`
+
+The issue file specifies test tables for end-to-end currency propagation that are not implemented:
+- `TestAppInitCurrencyDefault`, `TestAppInitCurrencyFromDB`, `TestCurrencyChangedPropagates` (app_test.go)
+- `TestMarketsCurrencyChanged`, `TestMarketsViewShowsCurrencyHeader` (markets_test.go)
+- `TestPortfolioCurrencyChanged`, `TestPortfolioPricesUpdatedReloadsHoldings`, `TestPortfolioViewShowsCurrency` (portfolio_test.go)
+
+These tests would validate that `currencyChangedMsg` correctly updates `AppModel.currency`, triggers a refresh in MarketsModel, and causes PortfolioModel to reload holdings after prices are updated. The issue file explicitly lists them as verification checkpoints.
+
+Once F1 is fixed, these tests should be added to provide coverage for the full currency-change flow.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -130,7 +130,7 @@ New runtime behaviour: the app must stay within the free-tier limit of ~30 req/m
 
 
 ## Slice 13 — Settings tab + currency data layer
-STATUS: IN_REVIEW
+STATUS: DONE
 
 UI and infrastructure only — Enter does not select a currency yet.
 
@@ -149,7 +149,7 @@ UI and infrastructure only — Enter does not select a currency yet.
 - **TDD:** store CRUD for settings/currencies, API mock for `FetchSupportedCurrencies`, settings model state transitions (browsing ↔ picking), search/filter logic, fiat filtering
 
 ## Slice 14 — Currency selection + correct price display
-STATUS: PENDING
+STATUS: IN_REVIEW
 
 Full end-to-end: select a currency → re-fetch data in that currency → display everywhere with correct values and code.
 

--- a/internal/api/coingecko.go
+++ b/internal/api/coingecko.go
@@ -47,8 +47,8 @@ func RetryAfterFromError(err error, defaultDuration time.Duration) time.Duration
 
 // CoinGeckoClient defines the interface for fetching cryptocurrency market data.
 type CoinGeckoClient interface {
-	FetchMarkets(ctx context.Context, limit int) ([]store.Coin, error)
-	FetchPrices(ctx context.Context, apiIDs []string) (map[string]float64, error)
+	FetchMarkets(ctx context.Context, currency string, limit int) ([]store.Coin, error)
+	FetchPrices(ctx context.Context, apiIDs []string, currency string) (map[string]float64, error)
 	FetchSupportedCurrencies(ctx context.Context) ([]string, error)
 }
 
@@ -128,13 +128,13 @@ type coinGeckoMarketResponse struct {
 }
 
 // FetchMarkets fetches market data for the top cryptocurrencies.
-func (c *HTTPClient) FetchMarkets(ctx context.Context, limit int) ([]store.Coin, error) {
+func (c *HTTPClient) FetchMarkets(ctx context.Context, currency string, limit int) ([]store.Coin, error) {
 	if err := c.throttle(ctx); err != nil {
 		return nil, err
 	}
 
 	params := url.Values{}
-	params.Set("vs_currency", "usd")
+	params.Set("vs_currency", currency)
 	params.Set("order", "market_cap_desc")
 	params.Set("per_page", strconv.Itoa(limit))
 	params.Set("page", "1")
@@ -208,8 +208,8 @@ func (c *HTTPClient) FetchMarkets(ctx context.Context, limit int) ([]store.Coin,
 type coinGeckoPriceResponse map[string]map[string]float64
 
 // FetchPrices fetches current prices for the given coin API IDs.
-// Returns a map of api_id -> USD price.
-func (c *HTTPClient) FetchPrices(ctx context.Context, apiIDs []string) (map[string]float64, error) {
+// Returns a map of api_id -> price in the specified currency.
+func (c *HTTPClient) FetchPrices(ctx context.Context, apiIDs []string, currency string) (map[string]float64, error) {
 	if err := c.throttle(ctx); err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func (c *HTTPClient) FetchPrices(ctx context.Context, apiIDs []string) (map[stri
 
 	params := url.Values{}
 	params.Set("ids", strings.Join(apiIDs, ","))
-	params.Set("vs_currencies", "usd")
+	params.Set("vs_currencies", currency)
 
 	u := c.baseURL + "/simple/price?" + params.Encode()
 
@@ -272,8 +272,8 @@ func (c *HTTPClient) FetchPrices(ctx context.Context, apiIDs []string) (map[stri
 
 	prices := make(map[string]float64, len(apiResp))
 	for apiID, priceData := range apiResp {
-		if usdPrice, ok := priceData["usd"]; ok {
-			prices[apiID] = usdPrice
+		if price, ok := priceData[currency]; ok {
+			prices[apiID] = price
 		}
 	}
 

--- a/internal/api/coingecko_test.go
+++ b/internal/api/coingecko_test.go
@@ -43,7 +43,7 @@ func TestFetchMarketsSuccess(t *testing.T) {
 		baseURL:    server.URL,
 	}
 
-	coins, err := client.FetchMarkets(context.Background(), 1)
+	coins, err := client.FetchMarkets(context.Background(), "usd", 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestFetchMarketsAPIError(t *testing.T) {
 		baseURL:    server.URL,
 	}
 
-	_, err := client.FetchMarkets(context.Background(), 1)
+	_, err := client.FetchMarkets(context.Background(), "usd", 1)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -118,7 +118,7 @@ func TestFetchMarketsNetworkError(t *testing.T) {
 		baseURL:    server.URL,
 	}
 
-	_, err := client.FetchMarkets(context.Background(), 1)
+	_, err := client.FetchMarkets(context.Background(), "usd", 1)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -139,7 +139,7 @@ func TestFetchMarketsContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	_, err := client.FetchMarkets(ctx, 1)
+	_, err := client.FetchMarkets(ctx, "usd", 1)
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
 	}
@@ -186,7 +186,7 @@ func TestFetchMarketsWithAPIKey(t *testing.T) {
 		apiKey:     "test-key",
 	}
 
-	_, err := client.FetchMarkets(context.Background(), 1)
+	_, err := client.FetchMarkets(context.Background(), "usd", 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -226,7 +226,7 @@ func TestFetchPricesSuccess(t *testing.T) {
 		baseURL:    server.URL,
 	}
 
-	prices, err := client.FetchPrices(context.Background(), []string{"bitcoin", "ethereum"})
+	prices, err := client.FetchPrices(context.Background(), []string{"bitcoin", "ethereum"}, "usd")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestFetchPricesEmptyIDs(t *testing.T) {
 		baseURL:    "http://localhost",
 	}
 
-	prices, err := client.FetchPrices(context.Background(), []string{})
+	prices, err := client.FetchPrices(context.Background(), []string{}, "usd")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestFetchPricesAPIError(t *testing.T) {
 		baseURL:    server.URL,
 	}
 
-	_, err := client.FetchPrices(context.Background(), []string{"bitcoin"})
+	_, err := client.FetchPrices(context.Background(), []string{"bitcoin"}, "usd")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -296,7 +296,7 @@ func TestFetchPricesContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := client.FetchPrices(ctx, []string{"bitcoin"})
+	_, err := client.FetchPrices(ctx, []string{"bitcoin"}, "usd")
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
 	}
@@ -326,7 +326,7 @@ func TestFetchPricesWithAPIKey(t *testing.T) {
 		apiKey:     "test-key",
 	}
 
-	prices, err := client.FetchPrices(context.Background(), []string{"bitcoin"})
+	prices, err := client.FetchPrices(context.Background(), []string{"bitcoin"}, "usd")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -360,13 +360,13 @@ func TestThrottleEnforcesMinimumInterval(t *testing.T) {
 
 	// First request
 	start := time.Now()
-	_, err := client.FetchMarkets(context.Background(), 1)
+	_, err := client.FetchMarkets(context.Background(), "usd", 1)
 	if err != nil {
 		t.Fatalf("unexpected error on first call: %v", err)
 	}
 
 	// Second request should be throttled
-	_, err = client.FetchMarkets(context.Background(), 1)
+	_, err = client.FetchMarkets(context.Background(), "usd", 1)
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("unexpected error on second call: %v", err)
@@ -393,7 +393,7 @@ func TestThrottleWithContextCancellation(t *testing.T) {
 	client := newHTTPClientWithInterval("", minInterval, server.URL)
 
 	// First request to set lastRequestAt
-	_, _ = client.FetchMarkets(context.Background(), 1)
+	_, _ = client.FetchMarkets(context.Background(), "usd", 1)
 
 	// Second request with cancelled context
 	ctx, cancel := context.WithCancel(context.Background())
@@ -402,7 +402,7 @@ func TestThrottleWithContextCancellation(t *testing.T) {
 		cancel()
 	}()
 
-	_, err := client.FetchMarkets(ctx, 1)
+	_, err := client.FetchMarkets(ctx, "usd", 1)
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
 	}
@@ -421,7 +421,7 @@ func TestFetchMarketsRateLimit429(t *testing.T) {
 
 	client := newHTTPClientWithInterval("", 10*time.Millisecond, server.URL)
 
-	_, err := client.FetchMarkets(context.Background(), 1)
+	_, err := client.FetchMarkets(context.Background(), "usd", 1)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -449,7 +449,7 @@ func TestFetchPricesRateLimit429(t *testing.T) {
 
 	client := newHTTPClientWithInterval("", 10*time.Millisecond, server.URL)
 
-	_, err := client.FetchPrices(context.Background(), []string{"bitcoin"})
+	_, err := client.FetchPrices(context.Background(), []string{"bitcoin"}, "usd")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -478,7 +478,7 @@ func TestFetchMarkets429WithRetryAfterHeader(t *testing.T) {
 
 	client := newHTTPClientWithInterval("", 10*time.Millisecond, server.URL)
 
-	_, err := client.FetchMarkets(context.Background(), 1)
+	_, err := client.FetchMarkets(context.Background(), "usd", 1)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -36,6 +36,23 @@ func FmtMoney(v float64, currency string) string {
 	return currencyCode(currency) + " " + addCommas(parts[0]) + "." + parts[1]
 }
 
+// FmtPriceValue formats a price value without the currency prefix.
+// Same rules as FmtPrice for decimal places, but omits the "USD " prefix.
+func FmtPriceValue(v float64) string {
+	if v >= 1 {
+		parts := strings.SplitN(fmt.Sprintf("%.2f", v), ".", 2)
+		return addCommas(parts[0]) + "." + parts[1]
+	}
+	return fmt.Sprintf("%.6f", v)
+}
+
+// FmtMoneyValue formats a holding value without the currency prefix.
+// Always 2 decimal places with thousands separator.
+func FmtMoneyValue(v float64) string {
+	parts := strings.SplitN(fmt.Sprintf("%.2f", v), ".", 2)
+	return addCommas(parts[0]) + "." + parts[1]
+}
+
 func addCommas(s string) string {
 	n := len(s)
 	if n <= 3 {

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -5,15 +5,21 @@ import (
 	"strings"
 )
 
-// FmtPrice formats a USD price:
-//   - v >= 1: "$X,XXX.XX" (2 dp, comma thousands separator)
-//   - v < 1:  "$0.XXXXXX" (6 dp)
-func FmtPrice(v float64) string {
+// currencyCode returns the uppercase 3-letter currency code.
+func currencyCode(currency string) string {
+	return strings.ToUpper(currency)
+}
+
+// FmtPrice formats a price in the given currency:
+//   - v >= 1: "USD X,XXX.XX" (2 dp, comma thousands separator)
+//   - v < 1:  "USD 0.XXXXXX" (6 dp)
+func FmtPrice(v float64, currency string) string {
+	prefix := currencyCode(currency)
 	if v >= 1 {
 		parts := strings.SplitN(fmt.Sprintf("%.2f", v), ".", 2)
-		return "$" + addCommas(parts[0]) + "." + parts[1]
+		return prefix + " " + addCommas(parts[0]) + "." + parts[1]
 	}
-	return fmt.Sprintf("$%.6f", v)
+	return fmt.Sprintf("%s %.6f", prefix, v)
 }
 
 // FmtChange formats a 24 h percentage change as "+X.XX%" or "-X.XX%".
@@ -24,10 +30,10 @@ func FmtChange(v float64) string {
 	return fmt.Sprintf("%.2f%%", v)
 }
 
-// FmtMoney formats a holding value as "$X,XXX.XX" (always 2 dp, thousands separator).
-func FmtMoney(v float64) string {
+// FmtMoney formats a holding value as "USD X,XXX.XX" (always 2 dp, thousands separator).
+func FmtMoney(v float64, currency string) string {
 	parts := strings.SplitN(fmt.Sprintf("%.2f", v), ".", 2)
-	return "$" + addCommas(parts[0]) + "." + parts[1]
+	return currencyCode(currency) + " " + addCommas(parts[0]) + "." + parts[1]
 }
 
 func addCommas(s string) string {

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -3,50 +3,50 @@ package format
 import "testing"
 
 func TestFmtPriceAboveOne(t *testing.T) {
-	got := FmtPrice(67234.56)
-	want := "$67,234.56"
+	got := FmtPrice(67234.56, "usd")
+	want := "USD 67,234.56"
 	if got != want {
-		t.Errorf("FmtPrice(67234.56) = %q, want %q", got, want)
+		t.Errorf("FmtPrice(67234.56, \"usd\") = %q, want %q", got, want)
 	}
 }
 
 func TestFmtPriceMillions(t *testing.T) {
-	got := FmtPrice(1234567.89)
-	want := "$1,234,567.89"
+	got := FmtPrice(1234567.89, "usd")
+	want := "USD 1,234,567.89"
 	if got != want {
-		t.Errorf("FmtPrice(1234567.89) = %q, want %q", got, want)
+		t.Errorf("FmtPrice(1234567.89, \"usd\") = %q, want %q", got, want)
 	}
 }
 
 func TestFmtPriceExactlyOne(t *testing.T) {
-	got := FmtPrice(1.0)
-	want := "$1.00"
+	got := FmtPrice(1.0, "usd")
+	want := "USD 1.00"
 	if got != want {
-		t.Errorf("FmtPrice(1.0) = %q, want %q", got, want)
+		t.Errorf("FmtPrice(1.0, \"usd\") = %q, want %q", got, want)
 	}
 }
 
 func TestFmtPriceBelowOne(t *testing.T) {
-	got := FmtPrice(0.00012345)
-	want := "$0.000123"
+	got := FmtPrice(0.00012345, "usd")
+	want := "USD 0.000123"
 	if got != want {
-		t.Errorf("FmtPrice(0.00012345) = %q, want %q", got, want)
+		t.Errorf("FmtPrice(0.00012345, \"usd\") = %q, want %q", got, want)
 	}
 }
 
 func TestFmtPriceSmallAboveOne(t *testing.T) {
-	got := FmtPrice(1.50)
-	want := "$1.50"
+	got := FmtPrice(1.50, "usd")
+	want := "USD 1.50"
 	if got != want {
-		t.Errorf("FmtPrice(1.50) = %q, want %q", got, want)
+		t.Errorf("FmtPrice(1.50, \"usd\") = %q, want %q", got, want)
 	}
 }
 
 func TestFmtPriceDecimalOverflow(t *testing.T) {
-	got := FmtPrice(99.995)
-	want := "$100.00"
+	got := FmtPrice(99.995, "usd")
+	want := "USD 100.00"
 	if got != want {
-		t.Errorf("FmtPrice(99.995) = %q, want %q", got, want)
+		t.Errorf("FmtPrice(99.995, \"usd\") = %q, want %q", got, want)
 	}
 }
 
@@ -75,25 +75,81 @@ func TestFmtChangeZero(t *testing.T) {
 }
 
 func TestFmtMoneyZero(t *testing.T) {
-	got := FmtMoney(0)
-	want := "$0.00"
+	got := FmtMoney(0, "usd")
+	want := "USD 0.00"
 	if got != want {
-		t.Errorf("FmtMoney(0) = %q, want %q", got, want)
+		t.Errorf("FmtMoney(0, \"usd\") = %q, want %q", got, want)
 	}
 }
 
 func TestFmtMoneySmall(t *testing.T) {
-	got := FmtMoney(0.5)
-	want := "$0.50"
+	got := FmtMoney(0.5, "usd")
+	want := "USD 0.50"
 	if got != want {
-		t.Errorf("FmtMoney(0.5) = %q, want %q", got, want)
+		t.Errorf("FmtMoney(0.5, \"usd\") = %q, want %q", got, want)
 	}
 }
 
 func TestFmtMoneyThousands(t *testing.T) {
-	got := FmtMoney(12345.678)
-	want := "$12,345.68"
+	got := FmtMoney(12345.678, "usd")
+	want := "USD 12,345.68"
 	if got != want {
-		t.Errorf("FmtMoney(12345.678) = %q, want %q", got, want)
+		t.Errorf("FmtMoney(12345.678, \"usd\") = %q, want %q", got, want)
+	}
+}
+
+func TestFmtPriceWithEur(t *testing.T) {
+	got := FmtPrice(1234.56, "eur")
+	want := "EUR 1,234.56"
+	if got != want {
+		t.Errorf("FmtPrice(1234.56, \"eur\") = %q, want %q", got, want)
+	}
+}
+
+func TestFmtPriceBelowOneWithEur(t *testing.T) {
+	got := FmtPrice(0.000123, "eur")
+	want := "EUR 0.000123"
+	if got != want {
+		t.Errorf("FmtPrice(0.000123, \"eur\") = %q, want %q", got, want)
+	}
+}
+
+func TestFmtPriceWithUnknownCurrency(t *testing.T) {
+	got := FmtPrice(1234.56, "brl")
+	want := "BRL 1,234.56"
+	if got != want {
+		t.Errorf("FmtPrice(1234.56, \"brl\") = %q, want %q", got, want)
+	}
+}
+
+func TestFmtMoneyWithEur(t *testing.T) {
+	got := FmtMoney(12345.67, "eur")
+	want := "EUR 12,345.67"
+	if got != want {
+		t.Errorf("FmtMoney(12345.67, \"eur\") = %q, want %q", got, want)
+	}
+}
+
+func TestFmtMoneyWithJpy(t *testing.T) {
+	got := FmtMoney(12345.67, "jpy")
+	want := "JPY 12,345.67"
+	if got != want {
+		t.Errorf("FmtMoney(12345.67, \"jpy\") = %q, want %q", got, want)
+	}
+}
+
+func TestCurrencyCodeLowerCase(t *testing.T) {
+	got := currencyCode("usd")
+	want := "USD"
+	if got != want {
+		t.Errorf("currencyCode(\"usd\") = %q, want %q", got, want)
+	}
+}
+
+func TestCurrencyCodeUpperCase(t *testing.T) {
+	got := currencyCode("EUR")
+	want := "EUR"
+	if got != want {
+		t.Errorf("currencyCode(\"EUR\") = %q, want %q", got, want)
 	}
 }

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -153,3 +153,43 @@ func TestCurrencyCodeUpperCase(t *testing.T) {
 		t.Errorf("currencyCode(\"EUR\") = %q, want %q", got, want)
 	}
 }
+
+func TestFmtPriceValueAboveOne(t *testing.T) {
+	got := FmtPriceValue(67234.56)
+	want := "67,234.56"
+	if got != want {
+		t.Errorf("FmtPriceValue(67234.56) = %q, want %q", got, want)
+	}
+}
+
+func TestFmtPriceValueBelowOne(t *testing.T) {
+	got := FmtPriceValue(0.00012345)
+	want := "0.000123"
+	if got != want {
+		t.Errorf("FmtPriceValue(0.00012345) = %q, want %q", got, want)
+	}
+}
+
+func TestFmtPriceValueExactlyOne(t *testing.T) {
+	got := FmtPriceValue(1.0)
+	want := "1.00"
+	if got != want {
+		t.Errorf("FmtPriceValue(1.0) = %q, want %q", got, want)
+	}
+}
+
+func TestFmtMoneyValueZero(t *testing.T) {
+	got := FmtMoneyValue(0)
+	want := "0.00"
+	if got != want {
+		t.Errorf("FmtMoneyValue(0) = %q, want %q", got, want)
+	}
+}
+
+func TestFmtMoneyValueThousands(t *testing.T) {
+	got := FmtMoneyValue(12345.678)
+	want := "12,345.68"
+	if got != want {
+		t.Errorf("FmtMoneyValue(12345.678) = %q, want %q", got, want)
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -115,6 +115,17 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
+		// Key messages go only to the active tab, never broadcast.
+		var cmd tea.Cmd
+		switch m.activeTab {
+		case tabMarkets:
+			m.markets, cmd = m.markets.update(msg)
+		case tabPortfolio:
+			m.portfolio, cmd = m.portfolio.update(msg)
+		case tabSettings:
+			m.settings, cmd = m.settings.update(msg)
+		}
+		return m, cmd
 
 	case currencyChangedMsg:
 		m.currency = msg.code

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -32,6 +32,11 @@ func tabBarInactiveStyle() lipgloss.Style {
 		Foreground(lipgloss.Color("#888888"))
 }
 
+// currencyChangedMsg is sent when the user selects a new currency.
+type currencyChangedMsg struct {
+	code string
+}
+
 // AppModel is the root Bubble Tea model. Owns tab bar, tab routing, global quit.
 type AppModel struct {
 	width     int
@@ -40,15 +45,21 @@ type AppModel struct {
 	markets   MarketsModel
 	portfolio PortfolioModel
 	settings  SettingsModel
+	currency  string
 }
 
 // NewAppModel creates a new AppModel with the given dependencies.
 func NewAppModel(ctx context.Context, s store.Store, c api.CoinGeckoClient) AppModel {
+	currency, _ := s.GetSetting(ctx, "selected_currency")
+	if currency == "" {
+		currency = "usd"
+	}
 	return AppModel{
 		activeTab: tabMarkets,
-		markets:   NewMarketsModel(ctx, s, c),
-		portfolio: NewPortfolioModel(ctx, s),
+		markets:   NewMarketsModel(ctx, s, c, currency),
+		portfolio: NewPortfolioModel(ctx, s, currency),
 		settings:  NewSettingsModel(ctx, s, c),
+		currency:  currency,
 	}
 }
 
@@ -104,6 +115,10 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
+
+	case currencyChangedMsg:
+		m.currency = msg.code
+		// Falls through to broadcast, which delivers the message to all children
 	}
 
 	// Background messages (non-key, non-resize) are always forwarded to all

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -477,3 +477,62 @@ func TestShiftTabCyclesBackwards(t *testing.T) {
 		t.Errorf("expected Shift+Tab to go Portfolio -> Markets, got %d", m.activeTab)
 	}
 }
+
+func TestAppInitCurrencyDefault(t *testing.T) {
+	// No selected_currency in settings - should default to "usd"
+	stub := &StubStore{settings: map[string]string{}}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+
+	if m.currency != "usd" {
+		t.Errorf("expected currency to default to 'usd', got '%s'", m.currency)
+	}
+}
+
+func TestAppInitCurrencyFromDB(t *testing.T) {
+	// selected_currency=eur in settings - should set currency to "eur"
+	stub := &StubStore{settings: map[string]string{"selected_currency": "eur"}}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+
+	if m.currency != "eur" {
+		t.Errorf("expected currency to be 'eur' from DB, got '%s'", m.currency)
+	}
+}
+
+func TestCurrencyChangedPropagates(t *testing.T) {
+	stub := &StubStore{}
+	api := &StubAPI{}
+	m := NewAppModel(context.Background(), stub, api)
+	m.width = 100
+	m.height = 30
+
+	// Set dimensions on children
+	m.markets.width = 100
+	m.markets.height = 29
+	m.portfolio.width = 100
+	m.portfolio.height = 29
+	m.settings.width = 100
+	m.settings.height = 29
+
+	// Send currencyChangedMsg
+	msg := currencyChangedMsg{code: "eur"}
+	updated, _ := m.Update(msg)
+	model := updated.(AppModel)
+
+	// Verify AppModel.currency updated
+	if model.currency != "eur" {
+		t.Errorf("expected AppModel.currency to be 'eur', got '%s'", model.currency)
+	}
+
+	// Verify message reached all children
+	if model.markets.currency != "eur" {
+		t.Errorf("expected MarketsModel.currency to be 'eur', got '%s'", model.markets.currency)
+	}
+	if model.portfolio.currency != "eur" {
+		t.Errorf("expected PortfolioModel.currency to be 'eur', got '%s'", model.portfolio.currency)
+	}
+	if model.settings.selectedCode != "eur" {
+		t.Errorf("expected SettingsModel.selectedCode to be 'eur', got '%s'", model.settings.selectedCode)
+	}
+}

--- a/internal/ui/markets.go
+++ b/internal/ui/markets.go
@@ -260,7 +260,7 @@ func (m MarketsModel) View() string {
 
 	for i := m.offset; i < end; i++ {
 		c := m.coins[i]
-		price := format.FmtPrice(c.Rate, m.currency)
+		price := format.FmtPriceValue(c.Rate)
 		change := format.FmtChange(c.PriceChange)
 
 		if c.PriceChange >= 0 {

--- a/internal/ui/markets.go
+++ b/internal/ui/markets.go
@@ -29,6 +29,7 @@ type MarketsModel struct {
 	offset           int
 	rateLimitedUntil time.Time // time at which rate-limit cooldown expires
 	refreshAttempts  int       // consecutive rate-limit errors (for backoff)
+	currency         string
 }
 
 // coinsLoadedMsg is sent when coins are successfully loaded from the API.
@@ -56,11 +57,12 @@ const (
 )
 
 // NewMarketsModel creates a new MarketsModel with the given dependencies.
-func NewMarketsModel(ctx context.Context, s store.Store, c api.CoinGeckoClient) MarketsModel {
+func NewMarketsModel(ctx context.Context, s store.Store, c api.CoinGeckoClient, currency string) MarketsModel {
 	return MarketsModel{
-		ctx:    ctx,
-		store:  s,
-		client: c,
+		ctx:      ctx,
+		store:    s,
+		client:   c,
+		currency: currency,
 	}
 }
 
@@ -87,7 +89,7 @@ func (m MarketsModel) cmdLoad() tea.Cmd {
 			return coinsLoadedMsg{coins: existing}
 		}
 
-		fetched, err := m.client.FetchMarkets(m.ctx, coinFetchLimit)
+		fetched, err := m.client.FetchMarkets(m.ctx, m.currency, coinFetchLimit)
 		if err != nil {
 			return errMsg{err: err}
 		}
@@ -149,6 +151,10 @@ func (m MarketsModel) update(msg tea.Msg) (MarketsModel, tea.Cmd) {
 			cmds = append(cmds, m.cmdRefresh())
 		}
 		return m, tea.Batch(cmds...)
+	case currencyChangedMsg:
+		m.currency = msg.code
+		m.refreshing = true
+		return m, m.cmdRefresh()
 	case coinsLoadedMsg:
 		m.coins = msg.coins
 		m.lastErr = ""
@@ -194,7 +200,7 @@ func (m MarketsModel) cmdRefresh() tea.Cmd {
 			apiIDs[i] = c.ApiID
 		}
 
-		prices, err := m.client.FetchPrices(m.ctx, apiIDs)
+		prices, err := m.client.FetchPrices(m.ctx, apiIDs, m.currency)
 		if err != nil {
 			return errMsg{err: err}
 		}
@@ -232,19 +238,20 @@ func (m MarketsModel) View() string {
 	wRank := 4
 	wName := 22
 	wTicker := 8
-	wPrice := 14
+	wPrice := 18
 	wChange := 9
 
 	highlight := lipgloss.NewStyle().Reverse(true)
 	green := lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00"))
 	red := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
 
+	currencyUpper := strings.ToUpper(m.currency)
 	header := fmt.Sprintf(
 		"%*s  %-*s  %-*s  %*s  %*s",
 		wRank, "#",
 		wName, "Name",
 		wTicker, "Ticker",
-		wPrice, "Price (USD)",
+		wPrice, "Price ("+currencyUpper+")",
 		wChange, "24h",
 	)
 
@@ -253,7 +260,7 @@ func (m MarketsModel) View() string {
 
 	for i := m.offset; i < end; i++ {
 		c := m.coins[i]
-		price := format.FmtPrice(c.Rate)
+		price := format.FmtPrice(c.Rate, m.currency)
 		change := format.FmtChange(c.PriceChange)
 
 		if c.PriceChange >= 0 {

--- a/internal/ui/markets_test.go
+++ b/internal/ui/markets_test.go
@@ -56,8 +56,8 @@ func TestMarketsCoinsLoadedMsg(t *testing.T) {
 		t.Errorf("expected view to contain 'BTC', got %q", view)
 	}
 
-	if !strings.Contains(view, "USD 67,000.00") {
-		t.Errorf("expected view to contain 'USD 67,000.00', got %q", view)
+	if !strings.Contains(view, "67,000.00") {
+		t.Errorf("expected view to contain '67,000.00', got %q", view)
 	}
 
 	if !strings.Contains(view, "Name") {

--- a/internal/ui/markets_test.go
+++ b/internal/ui/markets_test.go
@@ -14,7 +14,7 @@ import (
 func TestMarketsInitReturnsBatchedCmd(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	cmd := m.Init()
 
 	if cmd == nil {
@@ -25,7 +25,7 @@ func TestMarketsInitReturnsBatchedCmd(t *testing.T) {
 func TestMarketsCoinsLoadedMsg(t *testing.T) {
 	s := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, s, apiStub)
+	m := NewMarketsModel(testCtx, s, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 
@@ -56,8 +56,8 @@ func TestMarketsCoinsLoadedMsg(t *testing.T) {
 		t.Errorf("expected view to contain 'BTC', got %q", view)
 	}
 
-	if !strings.Contains(view, "$67,000.00") {
-		t.Errorf("expected view to contain '$67,000.00', got %q", view)
+	if !strings.Contains(view, "USD 67,000.00") {
+		t.Errorf("expected view to contain 'USD 67,000.00', got %q", view)
 	}
 
 	if !strings.Contains(view, "Name") {
@@ -77,7 +77,7 @@ func TestMarketsCoinsLoadedMsg(t *testing.T) {
 func TestMarketsErrMsg(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 
@@ -98,7 +98,7 @@ func TestMarketsErrMsg(t *testing.T) {
 func TestMarketsViewRendersLoading(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 
@@ -114,7 +114,7 @@ func TestMarketsViewRendersLoading(t *testing.T) {
 
 func TestMarketsViewRendersColumnHeaders(t *testing.T) {
 	coins := threeCoins()
-	m := NewMarketsModel(testCtx, &StubStore{coins: coins}, &StubAPI{})
+	m := NewMarketsModel(testCtx, &StubStore{coins: coins}, &StubAPI{}, "usd")
 	m.width = 120
 	m.height = 40
 	updated, _ := m.update(coinsLoadedMsg{coins: coins})
@@ -129,7 +129,7 @@ func TestMarketsViewRendersColumnHeaders(t *testing.T) {
 
 func TestMarketsViewRendersHintLine(t *testing.T) {
 	coins := threeCoins()
-	m := NewMarketsModel(testCtx, &StubStore{coins: coins}, &StubAPI{})
+	m := NewMarketsModel(testCtx, &StubStore{coins: coins}, &StubAPI{}, "usd")
 	m.width = 120
 	m.height = 40
 	updated, _ := m.update(coinsLoadedMsg{coins: coins})
@@ -143,7 +143,7 @@ func TestMarketsViewRendersHintLine(t *testing.T) {
 func TestMarketsRefreshKeyReturnsCmdWhenCoinsLoaded(t *testing.T) {
 	storeStub := &StubStore{coins: []store.Coin{{ApiID: "bitcoin", Name: "Bitcoin", Ticker: "BTC", Rate: 67000.00}}}
 	apiStub := &StubAPI{prices: map[string]float64{"bitcoin": 68000.00}}
-	m := NewMarketsModel(testCtx, storeStub, apiStub)
+	m := NewMarketsModel(testCtx, storeStub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 
@@ -165,7 +165,7 @@ func TestMarketsRefreshKeyReturnsCmdWhenCoinsLoaded(t *testing.T) {
 func TestMarketsRefreshKeyIgnoredWhenAlreadyRefreshing(t *testing.T) {
 	stub := &StubStore{coins: []store.Coin{{ApiID: "bitcoin", Name: "Bitcoin", Ticker: "BTC", Rate: 67000.00}}}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = stub.coins
@@ -182,7 +182,7 @@ func TestMarketsRefreshKeyIgnoredWhenAlreadyRefreshing(t *testing.T) {
 func TestMarketsRefreshKeyIgnoredWhenNoCoins(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 
@@ -197,7 +197,7 @@ func TestMarketsRefreshKeyIgnoredWhenNoCoins(t *testing.T) {
 func TestMarketsPricesUpdatedMsg(t *testing.T) {
 	storeStub := &StubStore{coins: []store.Coin{{ApiID: "bitcoin", Name: "Bitcoin", Ticker: "BTC", Rate: 68000.00}}}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, storeStub, apiStub)
+	m := NewMarketsModel(testCtx, storeStub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = []store.Coin{{ApiID: "bitcoin", Name: "Bitcoin", Ticker: "BTC", Rate: 67000.00}}
@@ -218,7 +218,7 @@ func TestMarketsPricesUpdatedMsg(t *testing.T) {
 func TestMarketsViewShowsRefreshHint(t *testing.T) {
 	stub := &StubStore{coins: []store.Coin{{ApiID: "bitcoin", Name: "Bitcoin", Ticker: "BTC", Rate: 67000.00, MarketRank: 1}}}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = stub.coins
@@ -300,7 +300,7 @@ func TestMarketsCursorMovesUpOnUpArrow(t *testing.T) {
 func TestMarketsMoveCursorNoPanicOnEmptyCoins(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 
@@ -318,7 +318,7 @@ func TestMarketsMoveCursorNoPanicOnEmptyCoins(t *testing.T) {
 func TestMarketsCursorClampedAfterCoinsLoaded(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 
@@ -332,7 +332,7 @@ func TestMarketsCursorClampedAfterCoinsLoaded(t *testing.T) {
 func TestMarketsTickMsgAlwaysReissuesTicker(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 
 	updated, cmd := m.update(tickMsg(time.Now()))
 
@@ -345,7 +345,7 @@ func TestMarketsTickMsgAlwaysReissuesTicker(t *testing.T) {
 func TestMarketsTickMsgBelow60sDoesNotRefresh(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.coins = threeCoins()
 	m.lastRefreshed = time.Now().Add(-30 * time.Second)
 
@@ -359,7 +359,7 @@ func TestMarketsTickMsgBelow60sDoesNotRefresh(t *testing.T) {
 func TestMarketsTickMsgAbove60sFiresRefresh(t *testing.T) {
 	stub := &StubStore{coins: threeCoins()}
 	apiStub := &StubAPI{prices: map[string]float64{"coin-1": 100.0}}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.coins = threeCoins()
 	m.lastRefreshed = time.Now().Add(-61 * time.Second)
 	m.refreshing = false
@@ -377,7 +377,7 @@ func TestMarketsTickMsgAbove60sFiresRefresh(t *testing.T) {
 func TestMarketsTickMsgWhenAlreadyRefreshing(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.coins = threeCoins()
 	m.lastRefreshed = time.Now().Add(-61 * time.Second)
 	m.refreshing = true
@@ -395,7 +395,7 @@ func TestMarketsTickMsgWhenAlreadyRefreshing(t *testing.T) {
 func TestMarketsTickMsgWhenNoCoins(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.lastRefreshed = time.Now().Add(-61 * time.Second)
 
 	updated, _ := m.update(tickMsg(time.Now()))
@@ -408,7 +408,7 @@ func TestMarketsTickMsgWhenNoCoins(t *testing.T) {
 func TestMarketsCoinsLoadedSetsLastRefreshed(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 
@@ -426,7 +426,7 @@ func TestMarketsCoinsLoadedSetsLastRefreshed(t *testing.T) {
 func TestMarketsPricesUpdatedSetsLastRefreshed(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = threeCoins()
@@ -445,7 +445,7 @@ func TestMarketsPricesUpdatedSetsLastRefreshed(t *testing.T) {
 func TestMarketsStatusBarShowsLoading(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 
@@ -458,7 +458,7 @@ func TestMarketsStatusBarShowsLoading(t *testing.T) {
 func TestMarketsStatusBarShowsRefreshing(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = threeCoins()
@@ -474,7 +474,7 @@ func TestMarketsStatusBarShowsRefreshing(t *testing.T) {
 func TestMarketsStatusBarShowsError(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = threeCoins()
@@ -490,7 +490,7 @@ func TestMarketsStatusBarShowsError(t *testing.T) {
 func TestMarketsStatusBarShowsSynced(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = threeCoins()
@@ -505,7 +505,7 @@ func TestMarketsStatusBarShowsSynced(t *testing.T) {
 func TestMarketsStatusBarShowsStale(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = threeCoins()
@@ -520,7 +520,7 @@ func TestMarketsStatusBarShowsStale(t *testing.T) {
 func TestMarketsTableRendersWhileError(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = threeCoins()
@@ -539,7 +539,7 @@ func TestMarketsTableRendersWhileError(t *testing.T) {
 func TestMarketsStatusBarHasHintsOnLeft(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = threeCoins()
@@ -555,7 +555,7 @@ func TestMarketsInitFetchesHundredCoinsOnFirstLaunch(t *testing.T) {
 	coins := threeCoins()
 	apiStub := &StubAPI{coins: coins}
 	s := &StubStore{}
-	m := NewMarketsModel(testCtx, s, apiStub)
+	m := NewMarketsModel(testCtx, s, apiStub, "usd")
 
 	msg := executeInitBatchForMarkets(t, m)
 
@@ -566,7 +566,7 @@ func TestMarketsInitFetchesHundredCoinsOnFirstLaunch(t *testing.T) {
 	if len(loaded.coins) != 3 {
 		t.Errorf("expected 3 coins, got %d", len(loaded.coins))
 	}
-	if len(apiStub.fetchMarketsCalls) != 1 || apiStub.fetchMarketsCalls[0] != 100 {
+	if len(apiStub.fetchMarketsCalls) != 1 || apiStub.fetchMarketsCalls[0].limit != 100 {
 		t.Errorf("expected FetchMarkets called with 100, got %v", apiStub.fetchMarketsCalls)
 	}
 }
@@ -575,7 +575,7 @@ func TestMarketsInitLoadsFromDBOnSubsequentLaunch(t *testing.T) {
 	coins := makeCoins(100)
 	apiStub := &StubAPI{coins: coins}
 	s := &StubStore{coins: coins}
-	m := NewMarketsModel(testCtx, s, apiStub)
+	m := NewMarketsModel(testCtx, s, apiStub, "usd")
 
 	msg := executeInitBatchForMarkets(t, m)
 
@@ -596,7 +596,7 @@ func TestMarketsInitRefetchesWhenDBPartiallySeeded(t *testing.T) {
 	full := makeCoins(100)
 	apiStub := &StubAPI{coins: full}
 	s := &StubStore{coins: partial}
-	m := NewMarketsModel(testCtx, s, apiStub)
+	m := NewMarketsModel(testCtx, s, apiStub, "usd")
 
 	msg := executeInitBatchForMarkets(t, m)
 
@@ -607,7 +607,7 @@ func TestMarketsInitRefetchesWhenDBPartiallySeeded(t *testing.T) {
 	if len(loaded.coins) != 100 {
 		t.Errorf("expected 100 coins after refetch, got %d", len(loaded.coins))
 	}
-	if len(apiStub.fetchMarketsCalls) != 1 || apiStub.fetchMarketsCalls[0] != 100 {
+	if len(apiStub.fetchMarketsCalls) != 1 || apiStub.fetchMarketsCalls[0].limit != 100 {
 		t.Errorf("expected FetchMarkets called with 100, got %v", apiStub.fetchMarketsCalls)
 	}
 }
@@ -615,7 +615,7 @@ func TestMarketsInitRefetchesWhenDBPartiallySeeded(t *testing.T) {
 func TestMarketsIgnoresOtherKeys(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	otherKeys := []rune{'a', 'b', 'c', 'x', 'z', '1', '2', ' '}
 	for _, key := range otherKeys {
 		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{key}}
@@ -629,7 +629,7 @@ func TestMarketsIgnoresOtherKeys(t *testing.T) {
 func TestMarketsInputActiveFalse(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	if m.InputActive() {
 		t.Error("expected InputActive() to return false for MarketsModel")
 	}
@@ -659,7 +659,7 @@ func executeInitBatchForMarkets(t *testing.T, m MarketsModel) tea.Msg {
 func TestMarketsRateLimitedErrMsg(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = threeCoins()
@@ -684,7 +684,7 @@ func TestMarketsRateLimitedErrMsg(t *testing.T) {
 func TestMarketsRateLimitedStatusBar(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = threeCoins()
@@ -703,7 +703,7 @@ func TestMarketsRateLimitedStatusBar(t *testing.T) {
 func TestMarketsRateLimitedStatusBarNoLongerLimited(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = threeCoins()
@@ -719,7 +719,7 @@ func TestMarketsRateLimitedStatusBarNoLongerLimited(t *testing.T) {
 func TestMarketsRefreshBlockedWhenRateLimited(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = threeCoins()
@@ -741,7 +741,7 @@ func TestMarketsRefreshBlockedWhenRateLimited(t *testing.T) {
 func TestMarketsAutoRefreshBlockedWhenRateLimited(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.coins = threeCoins()
 	m.lastRefreshed = time.Now().Add(-61 * time.Second)
 	m.refreshing = false
@@ -762,7 +762,7 @@ func TestMarketsAutoRefreshBlockedWhenRateLimited(t *testing.T) {
 func TestMarketsAutoRefreshResumesAfterCooldown(t *testing.T) {
 	stub := &StubStore{coins: threeCoins()}
 	apiStub := &StubAPI{prices: map[string]float64{"coin-1": 100.0}}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.coins = threeCoins()
 	m.lastRefreshed = time.Now().Add(-61 * time.Second)
 	m.refreshing = false
@@ -782,7 +782,7 @@ func TestMarketsAutoRefreshResumesAfterCooldown(t *testing.T) {
 func TestMarketsExponentialBackoffOnRepeated429(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = threeCoins()
@@ -828,7 +828,7 @@ func TestMarketsExponentialBackoffOnRepeated429(t *testing.T) {
 func TestMarketsBackoffResetOnSuccess(t *testing.T) {
 	stub := &StubStore{coins: threeCoins()}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = threeCoins()
@@ -850,7 +850,7 @@ func TestMarketsBackoffResetOnSuccess(t *testing.T) {
 func TestMarketsNonRateLimitErrorDoesNotSetRateLimitedUntil(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = threeCoins()
@@ -870,7 +870,7 @@ func TestMarketsNonRateLimitErrorDoesNotSetRateLimitedUntil(t *testing.T) {
 func TestMarketsRateLimitedStatusBarStyled(t *testing.T) {
 	stub := &StubStore{}
 	apiStub := &StubAPI{}
-	m := NewMarketsModel(testCtx, stub, apiStub)
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
 	m.width = 100
 	m.height = 30
 	m.coins = threeCoins()

--- a/internal/ui/markets_test.go
+++ b/internal/ui/markets_test.go
@@ -881,3 +881,45 @@ func TestMarketsRateLimitedStatusBarStyled(t *testing.T) {
 		t.Errorf("expected view to contain 'Rate limited', got %q", view)
 	}
 }
+
+func TestMarketsCurrencyChanged(t *testing.T) {
+	stub := &StubStore{coins: threeCoins()}
+	apiStub := &StubAPI{prices: map[string]float64{"coin-1": 0.85}}
+	m := NewMarketsModel(testCtx, stub, apiStub, "usd")
+	m.coins = threeCoins()
+	m.width = 100
+	m.height = 30
+
+	// Send currencyChangedMsg
+	msg := currencyChangedMsg{code: "eur"}
+	updated, cmd := m.update(msg)
+
+	// Verify currency updated
+	if updated.currency != "eur" {
+		t.Errorf("expected currency to be 'eur', got '%s'", updated.currency)
+	}
+
+	// Verify refreshing is true
+	if !updated.refreshing {
+		t.Error("expected refreshing to be true after currency change")
+	}
+
+	// Verify a refresh command is returned
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd after currency change")
+	}
+}
+
+func TestMarketsViewShowsCurrencyHeader(t *testing.T) {
+	stub := &StubStore{coins: threeCoins()}
+	apiStub := &StubAPI{}
+	m := NewMarketsModel(testCtx, stub, apiStub, "eur")
+	m.coins = threeCoins()
+	m.width = 100
+	m.height = 30
+
+	view := m.View()
+	if !strings.Contains(view, "Price (EUR)") {
+		t.Errorf("expected view to contain 'Price (EUR)', got %q", view)
+	}
+}

--- a/internal/ui/portfolio.go
+++ b/internal/ui/portfolio.go
@@ -111,14 +111,16 @@ type PortfolioModel struct {
 	scrollOffset   int // vertical scroll offset for holdings list preview
 	mode           portfolioMode
 	lastErr        string
+	currency       string
 }
 
 // NewPortfolioModel creates a new PortfolioModel with the given dependencies.
-func NewPortfolioModel(ctx context.Context, s store.Store) PortfolioModel {
+func NewPortfolioModel(ctx context.Context, s store.Store, currency string) PortfolioModel {
 	return PortfolioModel{
-		ctx:   ctx,
-		store: s,
-		mode:  browsing{},
+		ctx:      ctx,
+		store:    s,
+		mode:     browsing{},
+		currency: currency,
 	}
 }
 
@@ -577,6 +579,22 @@ func (m PortfolioModel) update(msg tea.Msg) (PortfolioModel, tea.Cmd) {
 	case errMsg:
 		m.lastErr = msg.err.Error()
 		return m, nil
+
+	case currencyChangedMsg:
+		m.currency = msg.code
+		// Don't reload holdings yet — prices in DB are still in the old currency.
+		// When MarketsModel finishes refreshing, pricesUpdatedMsg will be broadcast,
+		// and we'll reload holdings then.
+		return m, nil
+
+	case pricesUpdatedMsg:
+		// Prices in the DB have been updated (possibly in a new currency after a
+		// currency change). Reload holdings so Value, Proportion, and totals
+		// reflect the new rates.
+		if len(m.portfolios) > 0 {
+			return m, m.cmdLoadHoldings(m.portfolios[m.cursor].ID)
+		}
+		return m, nil
 	}
 
 	return m, nil
@@ -787,7 +805,7 @@ func (m PortfolioModel) renderRightPanel(height, width int) string {
 	}
 
 	var b strings.Builder
-	b.WriteString(titleStyle.Render(fmt.Sprintf("Holdings — %s (%s)", selectedPortfolio.Name, format.FmtMoney(totalValue))) + "\n")
+	b.WriteString(titleStyle.Render(fmt.Sprintf("Holdings — %s (%s)", selectedPortfolio.Name, format.FmtMoney(totalValue, m.currency))) + "\n")
 
 	if len(m.holdings) == 0 {
 		b.WriteString("no holdings — press a to add one")
@@ -835,8 +853,8 @@ func (m PortfolioModel) renderRightPanel(height, width int) string {
 			truncate(h.Name, 15),
 			h.Ticker,
 			h.Amount,
-			format.FmtPrice(h.Rate),
-			format.FmtMoney(h.Value),
+			format.FmtPrice(h.Rate, m.currency),
+			format.FmtMoney(h.Value, m.currency),
 			changeStr,
 			h.Proportion,
 		)
@@ -1179,7 +1197,7 @@ func (m PortfolioModel) renderDeleteDialog(mode deleting) string {
 	_, _ = fmt.Fprintf(&b, "Delete Holding\n\n")
 	_, _ = fmt.Fprintf(&b, "Coin: %s (%s)\n", mode.holding.Name, mode.holding.Ticker)
 	_, _ = fmt.Fprintf(&b, "Amount: %.4f\n", mode.holding.Amount)
-	_, _ = fmt.Fprintf(&b, "Value: %s\n\n", format.FmtMoney(mode.holding.Value))
+	_, _ = fmt.Fprintf(&b, "Value: %s\n\n", format.FmtMoney(mode.holding.Value, m.currency))
 	b.WriteString("Press Enter to confirm deletion, or Esc to cancel.")
 
 	return lipgloss.NewStyle().

--- a/internal/ui/portfolio.go
+++ b/internal/ui/portfolio.go
@@ -813,7 +813,8 @@ func (m PortfolioModel) renderRightPanel(height, width int) string {
 	}
 
 	// Header
-	_, _ = fmt.Fprintf(&b, "%-15s %8s %10s %12s %12s %8s %6s\n", "Coin", "Ticker", "Amount", "Price", "Value", "24h", "%")
+	currencyUpper := strings.ToUpper(m.currency)
+	_, _ = fmt.Fprintf(&b, "%-15s %8s %10s %12s %12s %8s %6s\n", "Coin", "Ticker", "Amount", "Price ("+currencyUpper+")", "Value ("+currencyUpper+")", "24h", "%")
 	b.WriteString(strings.Repeat("-", intMin(width, 80)) + "\n")
 
 	// Determine which rows to show based on mode and scroll offset
@@ -853,8 +854,8 @@ func (m PortfolioModel) renderRightPanel(height, width int) string {
 			truncate(h.Name, 15),
 			h.Ticker,
 			h.Amount,
-			format.FmtPrice(h.Rate, m.currency),
-			format.FmtMoney(h.Value, m.currency),
+			format.FmtPriceValue(h.Rate),
+			format.FmtMoneyValue(h.Value),
 			changeStr,
 			h.Proportion,
 		)

--- a/internal/ui/portfolio.go
+++ b/internal/ui/portfolio.go
@@ -662,8 +662,10 @@ func (m PortfolioModel) View() string {
 
 	contentHeight := m.height - 3 // Reserve 1 row for status bar, 2 for borders
 
-	// Define panel widths in terms of outer (total) columns and derive inner
-	leftPanelOuter := 30
+	// Define panel widths in terms of outer (total) columns and derive inner.
+	// Left panel is kept narrow (22) so the right panel has enough room for all
+	// holdings columns (77 chars) without wrapping.
+	leftPanelOuter := 22
 	rightPanelOuter := m.width - leftPanelOuter
 	leftPanelInner := leftPanelOuter - 2
 	rightPanelInner := rightPanelOuter - 2
@@ -814,7 +816,8 @@ func (m PortfolioModel) renderRightPanel(height, width int) string {
 
 	// Header
 	currencyUpper := strings.ToUpper(m.currency)
-	_, _ = fmt.Fprintf(&b, "%-15s %8s %10s %12s %12s %8s %6s\n", "Coin", "Ticker", "Amount", "Price ("+currencyUpper+")", "Value ("+currencyUpper+")", "24h", "%")
+	_, _ = fmt.Fprintf(&b, "%-15s %8s %10s %12s %12s %8s %6s\n",
+		"Coin", "Ticker", "Amount", "Price ("+currencyUpper+")", "Value ("+currencyUpper+")", "24h", "%")
 	b.WriteString(strings.Repeat("-", intMin(width, 80)) + "\n")
 
 	// Determine which rows to show based on mode and scroll offset
@@ -828,16 +831,13 @@ func (m PortfolioModel) renderRightPanel(height, width int) string {
 	inListMode := isListing || isEditing || isDeleting
 
 	if inListMode && visibleRows > 0 {
-		// In list mode, use holdingsCursor and scrollOffset
 		startIdx = m.scrollOffset
 		endIdx = intMin(startIdx+visibleRows, len(m.holdings))
 	} else if visibleRows > 0 {
-		// In browsing mode, use scrollOffset for preview scrolling
 		startIdx = m.scrollOffset
 		endIdx = intMin(startIdx+visibleRows, len(m.holdings))
 	}
 
-	// Ensure indices are valid
 	if startIdx < 0 {
 		startIdx = 0
 	}
@@ -851,16 +851,20 @@ func (m PortfolioModel) renderRightPanel(height, width int) string {
 		h := m.holdings[i]
 		changeStr := format.FmtChange(h.PriceChange)
 		line := fmt.Sprintf("%-15s %8s %10.4f %12s %12s %8s %5.1f%%",
-			truncate(h.Name, 15),
-			h.Ticker,
-			h.Amount,
-			format.FmtPriceValue(h.Rate),
-			format.FmtMoneyValue(h.Value),
-			changeStr,
-			h.Proportion,
-		)
-		// Highlight current row in list mode
+			truncate(h.Name, 15), h.Ticker, h.Amount,
+			format.FmtPriceValue(h.Rate), format.FmtMoneyValue(h.Value),
+			changeStr, h.Proportion)
+		// Clip or pad to width before applying ANSI reverse styling so the outer
+		// panel never word-wraps the highlighted row at an unexpected position.
 		if inListMode && i == m.holdingsCursor {
+			lw := lipgloss.Width(line)
+			switch {
+			case lw > width:
+				runes := []rune(line)
+				line = string(runes[:width])
+			case lw < width:
+				line += strings.Repeat(" ", width-lw)
+			}
 			line = highlight.Render(line)
 		}
 		b.WriteString(line + "\n")

--- a/internal/ui/portfolio_test.go
+++ b/internal/ui/portfolio_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNewPortfolioModel(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	if m.width != 0 || m.height != 0 {
 		t.Errorf("expected zero-value dimensions, got width=%d, height=%d", m.width, m.height)
 	}
@@ -28,14 +28,14 @@ func TestNewPortfolioModel(t *testing.T) {
 }
 
 func TestPortfolioInputActiveFalseWhenBrowsing(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	if m.InputActive() {
 		t.Error("expected InputActive() to return false when browsing")
 	}
 }
 
 func TestPortfolioInputActiveTrueWhenCreating(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	updated, _ := m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 	if !updated.InputActive() {
 		t.Error("expected InputActive() to return true after pressing 'n'")
@@ -43,7 +43,7 @@ func TestPortfolioInputActiveTrueWhenCreating(t *testing.T) {
 }
 
 func TestPortfolioNKeyOpensCreateDialog(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	updated, _ := m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 	if !updated.InputActive() {
 		t.Error("expected 'n' key to switch to creating mode")
@@ -51,7 +51,7 @@ func TestPortfolioNKeyOpensCreateDialog(t *testing.T) {
 }
 
 func TestPortfolioCreateDialogEscCancels(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 	if !m.InputActive() {
 		t.Fatal("expected to be in creating mode")
@@ -64,7 +64,7 @@ func TestPortfolioCreateDialogEscCancels(t *testing.T) {
 }
 
 func TestPortfolioCreateDialogEnterWithEmptyIsNoOp(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 	if !m.InputActive() {
 		t.Fatal("expected to be in creating mode")
@@ -80,7 +80,7 @@ func TestPortfolioCreateDialogEnterWithEmptyIsNoOp(t *testing.T) {
 }
 
 func TestPortfolioCreateDialogEnterWithTextReturnsCmd(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 	if !m.InputActive() {
 		t.Fatal("expected to be in creating mode")
@@ -107,7 +107,7 @@ func TestPortfolioCreateDialogEnterWithTextReturnsCmd(t *testing.T) {
 }
 
 func TestPortfolioJKNavigation(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 
@@ -134,7 +134,7 @@ func TestPortfolioJKNavigation(t *testing.T) {
 }
 
 func TestPortfolioCursorClampsAtTop(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 
@@ -153,7 +153,7 @@ func TestPortfolioCursorClampsAtTop(t *testing.T) {
 }
 
 func TestPortfolioCursorClampsAtBottom(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 
@@ -179,7 +179,7 @@ func TestPortfolioCursorClampsAtBottom(t *testing.T) {
 }
 
 func TestPortfoliosLoadedMsgPopulatesModel(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	threePortfolios := []store.Portfolio{
 		{ID: 1, Name: "A"},
 		{ID: 2, Name: "B"},
@@ -192,7 +192,7 @@ func TestPortfoliosLoadedMsgPopulatesModel(t *testing.T) {
 }
 
 func TestPortfoliosLoadedMsgPositionsCursorOnFocusID(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	threePortfolios := []store.Portfolio{
 		{ID: 1, Name: "A"},
 		{ID: 2, Name: "B"},
@@ -205,7 +205,7 @@ func TestPortfoliosLoadedMsgPositionsCursorOnFocusID(t *testing.T) {
 }
 
 func TestPortfoliosLoadedMsgSwitchesToBrowsing(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m, _ = m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 	if !m.InputActive() {
 		t.Fatal("expected to be in creating mode")
@@ -218,7 +218,7 @@ func TestPortfoliosLoadedMsgSwitchesToBrowsing(t *testing.T) {
 }
 
 func TestPortfolioViewShowsPortfolioNames(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{
@@ -236,7 +236,7 @@ func TestPortfolioViewShowsPortfolioNames(t *testing.T) {
 }
 
 func TestPortfolioViewShowsCursorIndicator(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{
@@ -261,7 +261,7 @@ func TestPortfolioViewShowsCursorIndicator(t *testing.T) {
 }
 
 func TestPortfolioViewShowsEmptyStateWhenNoPortfolios(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 
@@ -272,7 +272,7 @@ func TestPortfolioViewShowsEmptyStateWhenNoPortfolios(t *testing.T) {
 }
 
 func TestPortfolioHandlesWindowSizeMsg(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	updated, _ := m.update(tea.WindowSizeMsg{Width: 120, Height: 39})
 
 	if updated.width != 120 {
@@ -284,7 +284,7 @@ func TestPortfolioHandlesWindowSizeMsg(t *testing.T) {
 }
 
 func TestPortfolioAKeyInBrowsingModeIsNoOp(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	_, cmd := m.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
@@ -297,7 +297,7 @@ func TestPortfolioAKeyInListModeOpensCoinPicker(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios:  []store.Portfolio{{ID: 1, Name: "Test"}},
 		holdingRows: []store.HoldingRow{{ID: 1, CoinID: 1, Name: "Bitcoin", Ticker: "BTC"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	// Load portfolios and holdings into model, then enter list mode
@@ -313,7 +313,7 @@ func TestPortfolioAKeyInListModeOpensCoinPicker(t *testing.T) {
 func TestCoinPickerReadyMsgEntersAddCoinMode(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	coins := threeCoins()
@@ -326,7 +326,7 @@ func TestCoinPickerReadyMsgEntersAddCoinMode(t *testing.T) {
 func TestCoinPickerReadyMsgWithNoCoinsShowsError(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	updated, _ := m.update(coinPickerReadyMsg{coins: nil})
@@ -341,7 +341,7 @@ func TestCoinPickerReadyMsgWithNoCoinsShowsError(t *testing.T) {
 func TestCoinPickerFiltersOutAlreadyHeldCoins(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	// First load holdings - coin ID 1 is held
@@ -373,7 +373,7 @@ func TestCoinPickerAllHeldShowsError(t *testing.T) {
 			{CoinID: coins[1].ID},
 			{CoinID: coins[2].ID},
 		},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	m.holdings = []store.HoldingRow{
@@ -393,7 +393,7 @@ func TestCoinPickerAllHeldShowsError(t *testing.T) {
 func TestCoinPickerEscReturnsToBrowsing(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	coins := threeCoins()
@@ -410,7 +410,7 @@ func TestCoinPickerEscReturnsToBrowsing(t *testing.T) {
 func TestCoinPickerJKNavigatesCursor(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	coins := threeCoins()
@@ -433,7 +433,7 @@ func TestCoinPickerJKNavigatesCursor(t *testing.T) {
 func TestCoinPickerCursorClampsAtTop(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	coins := threeCoins()
@@ -454,7 +454,7 @@ func TestCoinPickerCursorClampsAtTop(t *testing.T) {
 func TestCoinPickerCursorClampsAtBottom(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	coins := threeCoins()
@@ -477,7 +477,7 @@ func TestCoinPickerCursorClampsAtBottom(t *testing.T) {
 func TestCoinPickerEnterTransitionsToAddAmount(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	coins := threeCoins()
@@ -498,7 +498,7 @@ func TestCoinPickerEnterTransitionsToAddAmount(t *testing.T) {
 func TestAddAmountEscReturnsToCoinPicker(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	coins := threeCoins()
@@ -515,7 +515,7 @@ func TestAddAmountEscReturnsToCoinPicker(t *testing.T) {
 func TestAddAmountEnterWithEmptyIsNoOp(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	coins := threeCoins()
@@ -535,7 +535,7 @@ func TestAddAmountEnterWithEmptyIsNoOp(t *testing.T) {
 func TestAddAmountEnterWithNonNumericSetsInlineError(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	coins := threeCoins()
@@ -563,7 +563,7 @@ func TestAddAmountEnterWithNonNumericSetsInlineError(t *testing.T) {
 func TestAddAmountEnterWithZeroOrNegativeSetsInlineError(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	coins := threeCoins()
@@ -586,7 +586,7 @@ func TestAddAmountEnterWithZeroOrNegativeSetsInlineError(t *testing.T) {
 func TestAddAmountEnterWithValidAmountReturnsCmd(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	// Load portfolios into model
@@ -606,7 +606,7 @@ func TestAddAmountEnterWithValidAmountReturnsCmd(t *testing.T) {
 }
 
 func TestHoldingsSavedMsgReturnsToBrowsing(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	updated, _ := m.update(holdingsSavedMsg{holdings: []store.HoldingRow{}})
 	if updated.InputActive() {
 		t.Error("expected holdingsSavedMsg to return to browsing mode")
@@ -614,7 +614,7 @@ func TestHoldingsSavedMsgReturnsToBrowsing(t *testing.T) {
 }
 
 func TestHoldingsSavedMsgUpdatesHoldings(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	rows := []store.HoldingRow{
 		{ID: 1, Name: "Bitcoin", Amount: 1.5},
 	}
@@ -625,7 +625,7 @@ func TestHoldingsSavedMsgUpdatesHoldings(t *testing.T) {
 }
 
 func TestHoldingsLoadedMsgUpdatesHoldings(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	rows := []store.HoldingRow{
 		{ID: 1, Name: "Bitcoin", Amount: 1.5},
 	}
@@ -690,7 +690,7 @@ func TestFilterCoinsNoMatch(t *testing.T) {
 // Slice 8 tests - List mode, Edit, Delete
 
 func TestEnterFromBrowsingToListingMode(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -710,7 +710,7 @@ func TestEnterFromBrowsingToListingMode(t *testing.T) {
 }
 
 func TestEnterFromBrowsingNoHoldingsEntersListMode(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -725,7 +725,7 @@ func TestEnterFromBrowsingNoHoldingsEntersListMode(t *testing.T) {
 }
 
 func TestListingJkNavigation(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -752,7 +752,7 @@ func TestListingJkNavigation(t *testing.T) {
 }
 
 func TestListingGJumpsToTop(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -771,7 +771,7 @@ func TestListingGJumpsToTop(t *testing.T) {
 }
 
 func TestListingGJumpsToBottom(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -790,7 +790,7 @@ func TestListingGJumpsToBottom(t *testing.T) {
 }
 
 func TestListingClampsAtTop(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -808,7 +808,7 @@ func TestListingClampsAtTop(t *testing.T) {
 }
 
 func TestListingClampsAtBottom(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -826,7 +826,7 @@ func TestListingClampsAtBottom(t *testing.T) {
 }
 
 func TestListingEscReturnsToBrowsing(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -843,7 +843,7 @@ func TestListingEscReturnsToBrowsing(t *testing.T) {
 }
 
 func TestListingEnterOpensEditDialog(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -860,7 +860,7 @@ func TestListingEnterOpensEditDialog(t *testing.T) {
 }
 
 func TestListingXOpensDeleteDialog(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -879,7 +879,7 @@ func TestListingXOpensDeleteDialog(t *testing.T) {
 func TestListingAOpensCoinPicker(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -895,7 +895,7 @@ func TestListingAOpensCoinPicker(t *testing.T) {
 }
 
 func TestEditAmountEscReturnsToListing(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -912,7 +912,7 @@ func TestEditAmountEscReturnsToListing(t *testing.T) {
 }
 
 func TestEditAmountEnterWithEmptyNoOp(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -932,7 +932,7 @@ func TestEditAmountEnterWithEmptyNoOp(t *testing.T) {
 }
 
 func TestEditAmountEnterWithNonNumericShowsError(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -962,7 +962,7 @@ func TestEditAmountEnterWithNonNumericShowsError(t *testing.T) {
 }
 
 func TestEditAmountEnterWithZeroOrNegativeShowsError(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -989,7 +989,7 @@ func TestEditAmountEnterWithZeroOrNegativeShowsError(t *testing.T) {
 func TestEditAmountEnterWithValidAmountReturnsCmd(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -1012,7 +1012,7 @@ func TestEditAmountEnterWithValidAmountReturnsCmd(t *testing.T) {
 }
 
 func TestEditingAmountInputActive(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.mode = editingAmount{}
 	if !m.InputActive() {
 		t.Error("expected InputActive() to be true for editingAmount mode")
@@ -1020,7 +1020,7 @@ func TestEditingAmountInputActive(t *testing.T) {
 }
 
 func TestDeleteConfirmEscReturnsToListing(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -1038,7 +1038,7 @@ func TestDeleteConfirmEscReturnsToListing(t *testing.T) {
 func TestDeleteConfirmEnterReturnsCmd(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -1054,7 +1054,7 @@ func TestDeleteConfirmEnterReturnsCmd(t *testing.T) {
 }
 
 func TestDeletingInputActive(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.mode = deleting{}
 	if m.InputActive() {
 		t.Error("expected InputActive() to be false for deleting mode")
@@ -1062,7 +1062,7 @@ func TestDeletingInputActive(t *testing.T) {
 }
 
 func TestDeleteConfirmOtherKeysIgnored(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -1081,7 +1081,7 @@ func TestDeleteConfirmOtherKeysIgnored(t *testing.T) {
 }
 
 func TestCursorClampedAfterDelete(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -1099,7 +1099,7 @@ func TestCursorClampedAfterDelete(t *testing.T) {
 }
 
 func TestCursorStaysAtSamePositionAfterDelete(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -1122,7 +1122,7 @@ func TestCursorStaysAtSamePositionAfterDelete(t *testing.T) {
 }
 
 func TestHoldingDeletedMsgUpdatesHoldings(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.holdings = []store.HoldingRow{
 		{ID: 1, Name: "Bitcoin"},
 		{ID: 2, Name: "Ethereum"},
@@ -1137,7 +1137,7 @@ func TestHoldingDeletedMsgUpdatesHoldings(t *testing.T) {
 }
 
 func TestHoldingDeletedMsgClampsCursor(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.holdings = []store.HoldingRow{
 		{ID: 1, Name: "Bitcoin"},
 		{ID: 2, Name: "Ethereum"},
@@ -1153,7 +1153,7 @@ func TestHoldingDeletedMsgClampsCursor(t *testing.T) {
 }
 
 func TestHoldingDeletedMsgReturnsToListing(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.holdings = []store.HoldingRow{
 		{ID: 1, Name: "Bitcoin"},
 		{ID: 2, Name: "Ethereum"},
@@ -1169,7 +1169,7 @@ func TestHoldingDeletedMsgReturnsToListing(t *testing.T) {
 }
 
 func TestHoldingDeletedMsgToBrowsingWhenEmpty(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.holdings = []store.HoldingRow{
 		{ID: 1, Name: "Bitcoin"},
 	}
@@ -1182,7 +1182,7 @@ func TestHoldingDeletedMsgToBrowsingWhenEmpty(t *testing.T) {
 }
 
 func TestHoldingsSavedFromEditReturnsToListing(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.holdings = []store.HoldingRow{
 		{ID: 1, Name: "Bitcoin"},
 	}
@@ -1197,7 +1197,7 @@ func TestHoldingsSavedFromEditReturnsToListing(t *testing.T) {
 }
 
 func TestHoldingsSavedFromAddReturnsToBrowsing(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.holdings = []store.HoldingRow{}
 	m.mode = addAmount{}
 
@@ -1210,7 +1210,7 @@ func TestHoldingsSavedFromAddReturnsToBrowsing(t *testing.T) {
 }
 
 func TestBrowsingPgDnScrollsHoldingsPreview(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -1226,7 +1226,7 @@ func TestBrowsingPgDnScrollsHoldingsPreview(t *testing.T) {
 }
 
 func TestBrowsingPgUpScrollsHoldingsPreview(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -1243,7 +1243,7 @@ func TestBrowsingPgUpScrollsHoldingsPreview(t *testing.T) {
 }
 
 func TestBrowsingPgUpDoesNotGoBelowZero(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -1259,7 +1259,7 @@ func TestBrowsingPgUpDoesNotGoBelowZero(t *testing.T) {
 }
 
 func TestBrowsingJkResetsScrollOffset(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{
@@ -1279,7 +1279,7 @@ func TestBrowsingJkResetsScrollOffset(t *testing.T) {
 }
 
 func TestListingModeShowsPanelFocus(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -1295,7 +1295,7 @@ func TestListingModeShowsPanelFocus(t *testing.T) {
 }
 
 func TestBrowsingModeShowsPanelFocus(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -1311,7 +1311,7 @@ func TestBrowsingModeShowsPanelFocus(t *testing.T) {
 }
 
 func TestEditDialogShowsCoinName(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -1331,7 +1331,7 @@ func TestEditDialogShowsCoinName(t *testing.T) {
 }
 
 func TestDeleteDialogShowsCoinName(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -1352,7 +1352,7 @@ func TestDeleteDialogShowsCoinName(t *testing.T) {
 }
 
 func TestPortfolioViewShowsHoldingsTable(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -1366,7 +1366,7 @@ func TestPortfolioViewShowsHoldingsTable(t *testing.T) {
 }
 
 func TestPortfolioViewShowsNoHoldingsMessage(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{{ID: 1, Name: "Test"}}
@@ -1378,7 +1378,7 @@ func TestPortfolioViewShowsNoHoldingsMessage(t *testing.T) {
 }
 
 func TestPortfolioInputActiveForAddCoinMode(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.mode = addCoin{}
 	if !m.InputActive() {
 		t.Error("expected InputActive() to be true for addCoin mode")
@@ -1386,7 +1386,7 @@ func TestPortfolioInputActiveForAddCoinMode(t *testing.T) {
 }
 
 func TestPortfolioInputActiveForAddAmountMode(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.mode = addAmount{}
 	if !m.InputActive() {
 		t.Error("expected InputActive() to be true for addAmount mode")
@@ -1396,7 +1396,7 @@ func TestPortfolioInputActiveForAddAmountMode(t *testing.T) {
 // Slice 9 tests - Portfolio Edit and Delete
 
 func TestBrowsingEKeyOpensEditDialog(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{
@@ -1411,7 +1411,7 @@ func TestBrowsingEKeyOpensEditDialog(t *testing.T) {
 }
 
 func TestBrowsingEKeyNoPortfoliosIsNoOp(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{}
@@ -1424,7 +1424,7 @@ func TestBrowsingEKeyNoPortfoliosIsNoOp(t *testing.T) {
 }
 
 func TestEditingPortfolioEscReturnsToBrowsing(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.mode = editingPortfolio{
@@ -1440,7 +1440,7 @@ func TestEditingPortfolioEscReturnsToBrowsing(t *testing.T) {
 }
 
 func TestEditingPortfolioEnterWithEmptyNameReturnsToBrowsing(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	ti := textinput.New()
@@ -1457,7 +1457,7 @@ func TestEditingPortfolioEnterWithEmptyNameReturnsToBrowsing(t *testing.T) {
 }
 
 func TestEditingPortfolioEnterWithSameNameReturnsToBrowsing(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	ti := textinput.New()
@@ -1475,7 +1475,7 @@ func TestEditingPortfolioEnterWithSameNameReturnsToBrowsing(t *testing.T) {
 }
 
 func TestEditingPortfolioEnterWithDuplicateNameShowsError(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{
@@ -1505,7 +1505,7 @@ func TestEditingPortfolioEnterWithValidNameReturnsCmd(t *testing.T) {
 		portfolios: []store.Portfolio{
 			{ID: 1, Name: "Old Name"},
 		},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{
@@ -1527,7 +1527,7 @@ func TestEditingPortfolioEnterWithValidNameReturnsCmd(t *testing.T) {
 }
 
 func TestEditingPortfolioInputActive(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.mode = editingPortfolio{}
 
 	if !m.InputActive() {
@@ -1536,7 +1536,7 @@ func TestEditingPortfolioInputActive(t *testing.T) {
 }
 
 func TestEditingPortfolioPrePopulatedName(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{
@@ -1555,7 +1555,7 @@ func TestEditingPortfolioPrePopulatedName(t *testing.T) {
 }
 
 func TestBrowsingXKeyOpensDeleteDialog(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{
@@ -1570,7 +1570,7 @@ func TestBrowsingXKeyOpensDeleteDialog(t *testing.T) {
 }
 
 func TestBrowsingXKeyNoPortfoliosIsNoOp(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{}
@@ -1583,7 +1583,7 @@ func TestBrowsingXKeyNoPortfoliosIsNoOp(t *testing.T) {
 }
 
 func TestDeletingPortfolioEscReturnsToBrowsing(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.mode = deletingPortfolio{
@@ -1602,7 +1602,7 @@ func TestDeletingPortfolioEnterReturnsCmd(t *testing.T) {
 		portfolios: []store.Portfolio{
 			{ID: 1, Name: "Test"},
 		},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{
@@ -1620,7 +1620,7 @@ func TestDeletingPortfolioEnterReturnsCmd(t *testing.T) {
 }
 
 func TestDeletingPortfolioOtherKeysIgnored(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.mode = deletingPortfolio{
@@ -1637,7 +1637,7 @@ func TestDeletingPortfolioOtherKeysIgnored(t *testing.T) {
 }
 
 func TestDeletingPortfolioInputActive(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.mode = deletingPortfolio{}
 
 	if m.InputActive() {
@@ -1646,7 +1646,7 @@ func TestDeletingPortfolioInputActive(t *testing.T) {
 }
 
 func TestPortfolioDeletedMsgUpdatesPortfolios(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.portfolios = []store.Portfolio{
 		{ID: 1, Name: "Portfolio A"},
 		{ID: 2, Name: "Portfolio B"},
@@ -1664,7 +1664,7 @@ func TestPortfolioDeletedMsgUpdatesPortfolios(t *testing.T) {
 }
 
 func TestPortfolioDeletedMsgClampsCursor(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.portfolios = []store.Portfolio{
 		{ID: 1, Name: "Portfolio A"},
 		{ID: 2, Name: "Portfolio B"},
@@ -1685,7 +1685,7 @@ func TestPortfolioDeletedMsgClampsCursor(t *testing.T) {
 }
 
 func TestPortfolioDeletedMsgResetsScrollOffset(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.portfolios = []store.Portfolio{
 		{ID: 1, Name: "Portfolio A"},
 	}
@@ -1699,7 +1699,7 @@ func TestPortfolioDeletedMsgResetsScrollOffset(t *testing.T) {
 }
 
 func TestPortfolioDeletedMsgToBrowsingWhenEmpty(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.portfolios = []store.Portfolio{
 		{ID: 1, Name: "Portfolio A"},
 	}
@@ -1721,7 +1721,7 @@ func TestPortfolioDeletedMsgLoadsHoldingsForNewSelection(t *testing.T) {
 		portfolios: []store.Portfolio{
 			{ID: 1, Name: "Remaining"},
 		},
-	})
+	}, "usd")
 	m.portfolios = []store.Portfolio{
 		{ID: 1, Name: "To Delete"},
 		{ID: 2, Name: "Remaining"},
@@ -1741,7 +1741,7 @@ func TestPortfolioDeletedMsgLoadsHoldingsForNewSelection(t *testing.T) {
 }
 
 func TestEditPortfolioDialogShowsCurrentName(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{
@@ -1761,7 +1761,7 @@ func TestEditPortfolioDialogShowsCurrentName(t *testing.T) {
 }
 
 func TestDeletePortfolioDialogShowsName(t *testing.T) {
-	m := NewPortfolioModel(testCtx, &StubStore{})
+	m := NewPortfolioModel(testCtx, &StubStore{}, "usd")
 	m.width = 100
 	m.height = 30
 	m.portfolios = []store.Portfolio{
@@ -1780,7 +1780,7 @@ func TestDeletePortfolioDialogShowsName(t *testing.T) {
 func TestCoinPickerTypingFilters(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	coins := []store.Coin{
@@ -1807,7 +1807,7 @@ func TestCoinPickerTypingFilters(t *testing.T) {
 func TestCoinPickerCursorClampedAfterFilter(t *testing.T) {
 	m := NewPortfolioModel(testCtx, &StubStore{
 		portfolios: []store.Portfolio{{ID: 1, Name: "Test"}},
-	})
+	}, "usd")
 	m.width = 100
 	m.height = 30
 	coins := []store.Coin{

--- a/internal/ui/portfolio_test.go
+++ b/internal/ui/portfolio_test.go
@@ -1844,3 +1844,76 @@ func TestCoinPickerCursorClampedAfterFilter(t *testing.T) {
 		t.Fatal("expected to be in addCoin mode")
 	}
 }
+
+func TestPortfolioCurrencyChanged(t *testing.T) {
+	stub := &StubStore{
+		portfolios:  []store.Portfolio{{ID: 1, Name: "Test"}},
+		holdingRows: []store.HoldingRow{{ID: 1, PortfolioID: 1, Amount: 1.0, CoinID: 1, Ticker: "BTC", Name: "Bitcoin", Rate: 50000.0}},
+	}
+	m := NewPortfolioModel(testCtx, stub, "usd")
+	m.portfolios = stub.portfolios
+	m.holdings = stub.holdingRows
+	m.width = 100
+	m.height = 30
+
+	// Track if holdings were reloaded (they should NOT be on currency change alone)
+	originalHoldings := m.holdings
+
+	// Send currencyChangedMsg
+	msg := currencyChangedMsg{code: "eur"}
+	updated, cmd := m.update(msg)
+
+	// Verify currency updated
+	if updated.currency != "eur" {
+		t.Errorf("expected currency to be 'eur', got '%s'", updated.currency)
+	}
+
+	// Verify holdings were NOT reloaded immediately (DB still has old prices)
+	if cmd != nil {
+		t.Error("expected no cmd (no immediate reload) after currency change")
+	}
+	if len(updated.holdings) != len(originalHoldings) {
+		t.Error("expected holdings to not change immediately after currency change")
+	}
+}
+
+func TestPortfolioPricesUpdatedReloadsHoldings(t *testing.T) {
+	stub := &StubStore{
+		portfolios:  []store.Portfolio{{ID: 1, Name: "Test"}},
+		holdingRows: []store.HoldingRow{{ID: 1, PortfolioID: 1, Amount: 1.0, CoinID: 1, Ticker: "BTC", Name: "Bitcoin", Rate: 45000.0}},
+	}
+	m := NewPortfolioModel(testCtx, stub, "usd")
+	m.portfolios = stub.portfolios
+	m.cursor = 0
+	m.width = 100
+	m.height = 30
+
+	// Send pricesUpdatedMsg (simulating MarketsModel finishing refresh)
+	msg := pricesUpdatedMsg{coins: []store.Coin{{ID: 1, ApiID: "bitcoin", Ticker: "BTC", Name: "Bitcoin", Rate: 50000.0}}}
+	_, cmd := m.update(msg)
+
+	// Verify holdings reload is triggered
+	if cmd == nil {
+		t.Fatal("expected cmd to reload holdings after pricesUpdatedMsg")
+	}
+}
+
+func TestPortfolioViewShowsCurrency(t *testing.T) {
+	stub := &StubStore{
+		portfolios:  []store.Portfolio{{ID: 1, Name: "Test"}},
+		holdingRows: []store.HoldingRow{{ID: 1, PortfolioID: 1, Amount: 1.5, CoinID: 1, Ticker: "BTC", Name: "Bitcoin", Rate: 50000.0}},
+	}
+	m := NewPortfolioModel(testCtx, stub, "eur")
+	m.portfolios = stub.portfolios
+	m.holdings = stub.holdingRows
+	m.cursor = 0
+	m.width = 100
+	m.height = 30
+
+	view := m.View()
+
+	// Verify EUR appears in the view (in headers or values)
+	if !strings.Contains(view, "EUR") {
+		t.Errorf("expected view to contain 'EUR' currency code, got %q", view)
+	}
+}

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -115,6 +115,9 @@ func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 		m.loading = false
 		m.lastErr = msg.err.Error()
 
+	case currencyChangedMsg:
+		m.selectedCode = msg.code
+
 	case tea.KeyMsg:
 		switch mode := m.mode.(type) {
 		case settingsBrowsing:
@@ -138,8 +141,21 @@ func (m SettingsModel) update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 				return m, nil
 
 			case tea.KeyEnter:
-				// No-op for Slice 13 - selection handled in Slice 14
-				return m, nil
+				// Guard against empty filtered list
+				if len(picking.filtered) == 0 {
+					return m, nil
+				}
+				selected := picking.filtered[picking.cursor]
+				// Persist to database
+				if err := m.store.SetSetting(m.ctx, "selected_currency", selected.Code); err != nil {
+					m.lastErr = err.Error()
+					return m, nil
+				}
+				// Update selected code and transition to browsing
+				m.selectedCode = selected.Code
+				m.mode = settingsBrowsing{}
+				// Emit currency changed message to trigger refresh in other tabs
+				return m, func() tea.Msg { return currencyChangedMsg{code: selected.Code} }
 
 			case tea.KeyDown:
 				if picking.cursor < len(picking.filtered)-1 {

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -193,9 +193,10 @@ func TestSettingsPickEscReturnsToBrowsing(t *testing.T) {
 	}
 }
 
-func TestSettingsPickEnterNoOp(t *testing.T) {
+func TestSettingsPickEnterSelectsCurrency(t *testing.T) {
 	currencies := []store.Currency{
 		{Code: "usd", Name: "US Dollar"},
+		{Code: "eur", Name: "Euro"},
 	}
 	stub := &StubStore{currencies: currencies}
 	api := &StubAPI{}
@@ -205,11 +206,38 @@ func TestSettingsPickEnterNoOp(t *testing.T) {
 	// Enter picking mode
 	m, _ = m.update(tea.KeyMsg{Type: tea.KeyEnter})
 
-	// Press Enter - should be no-op (Slice 14 wires it)
-	_, cmd := m.update(tea.KeyMsg{Type: tea.KeyEnter})
+	// Move cursor to second currency (EUR)
+	m, _ = m.update(tea.KeyMsg{Type: tea.KeyDown})
 
-	if cmd != nil {
-		t.Error("expected no command from Enter in picking mode (Slice 13)")
+	// Press Enter to select
+	m, cmd := m.update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Verify command returns currencyChangedMsg
+	if cmd == nil {
+		t.Fatal("expected command from Enter in picking mode, got nil")
+	}
+	msg := cmd()
+	changedMsg, ok := msg.(currencyChangedMsg)
+	if !ok {
+		t.Fatalf("expected currencyChangedMsg, got %T", msg)
+	}
+	if changedMsg.code != "eur" {
+		t.Errorf("expected currency code 'eur', got '%s'", changedMsg.code)
+	}
+
+	// Verify mode transitioned to browsing
+	if m.InputActive() {
+		t.Error("expected browsing mode after selection, still in picking mode")
+	}
+
+	// Verify selectedCode updated
+	if m.selectedCode != "eur" {
+		t.Errorf("expected selectedCode 'eur', got '%s'", m.selectedCode)
+	}
+
+	// Verify SetSetting was called
+	if stub.settings == nil || stub.settings["selected_currency"] != "eur" {
+		t.Error("expected SetSetting to be called with selected_currency=eur")
 	}
 }
 

--- a/internal/ui/testhelpers_test.go
+++ b/internal/ui/testhelpers_test.go
@@ -145,24 +145,29 @@ func (s *StubStore) SetSetting(ctx context.Context, key, value string) error {
 	return nil
 }
 
+type fetchMarketsCall struct {
+	currency string
+	limit    int
+}
+
 // StubAPI implements api.CoinGeckoClient for testing
 type StubAPI struct {
 	coins               []store.Coin
 	prices              map[string]float64
 	supportedCurrencies []string
 	err                 error
-	fetchMarketsCalls   []int
+	fetchMarketsCalls   []fetchMarketsCall
 }
 
-func (a *StubAPI) FetchMarkets(ctx context.Context, limit int) ([]store.Coin, error) {
-	a.fetchMarketsCalls = append(a.fetchMarketsCalls, limit)
+func (a *StubAPI) FetchMarkets(ctx context.Context, currency string, limit int) ([]store.Coin, error) {
+	a.fetchMarketsCalls = append(a.fetchMarketsCalls, fetchMarketsCall{currency: currency, limit: limit})
 	if a.err != nil {
 		return nil, a.err
 	}
 	return a.coins, nil
 }
 
-func (a *StubAPI) FetchPrices(ctx context.Context, apiIDs []string) (map[string]float64, error) {
+func (a *StubAPI) FetchPrices(ctx context.Context, apiIDs []string, currency string) (map[string]float64, error) {
 	if a.err != nil {
 		return nil, a.err
 	}
@@ -200,7 +205,7 @@ var testCtx = context.Background()
 // setupMarketsModel creates a MarketsModel with pre-loaded coins for cursor tests.
 func setupMarketsModel(t *testing.T, coins []store.Coin) MarketsModel {
 	t.Helper()
-	m := NewMarketsModel(testCtx, &StubStore{coins: coins}, &StubAPI{})
+	m := NewMarketsModel(testCtx, &StubStore{coins: coins}, &StubAPI{}, "usd")
 	m.width = 120
 	m.height = 40
 	updated, _ := m.update(coinsLoadedMsg{coins: coins})


### PR DESCRIPTION
## Summary

- Implement currency selection in Settings tab, propagating the chosen currency across Markets and Portfolio tabs
- Add multi-currency price fetching from CoinGecko — prices are now requested and displayed in the selected currency
- Fix portfolio tab bugs: key leak, row alignment, left panel width, and currency ticker placement in table headers

## Test Plan

- [ ] Launch app, navigate to Settings tab, change currency — verify Markets and Portfolio tabs update prices accordingly
- [ ] Confirm price formatting respects the selected currency (symbol, decimal places)
- [ ] Verify portfolio holdings values reflect the selected currency
- [ ] Check table layout is stable when switching currencies
- [ ] `make test` passes with race detector clean